### PR TITLE
FIXED: DataTable Set Var now uses correct indices for DataTableEntry.…

### DIFF
--- a/WolvenKit/Forms/frmDebug.cs
+++ b/WolvenKit/Forms/frmDebug.cs
@@ -237,9 +237,9 @@ namespace WolvenKit
         {
             if (e.ColumnIndex == 2)
             {
-                Send(GameSocket, Commands.SetVar(varDGV[e.ColumnIndex, 0].Value.ToString(),
-                    varDGV[e.ColumnIndex, 1].Value.ToString(),
-                    varDGV[e.ColumnIndex, 2].Value.ToString()));
+                Send(GameSocket, Commands.SetVar(varDGV[0, e.RowIndex].Value.ToString(),
+                    varDGV[1, e.RowIndex].Value.ToString(),
+                    varDGV[2, e.RowIndex].Value.ToString()));
             }
         }
 


### PR DESCRIPTION
… Row/Column was switched

# DataTable Set Var now uses correct indices for DataTableEntry. Row/Column was switched

Fixed:
- Usage of DataTableEntry indices