### PR TITLE
Fixed compile warnings.

### DIFF
--- a/Wolvekit.Nvidia/HairWorks/NvHairAssetHeaderInfo.cs
+++ b/Wolvekit.Nvidia/HairWorks/NvHairAssetHeaderInfo.cs
@@ -35,11 +35,11 @@ namespace Wolvekit.Nvidia.HairWorks
         {
             var HairWorksInfo = NvidiaXML.CreateStructHeader("", "Ref", "HairWorksInfo", "1.0", checksum);
             var values = new XElement("struct", new XAttribute("name", ""));
-            values.AddNvValue("fileVersion", "String", "1.0");
-            values.AddNvValue("toolVersion","String","WolvenKit");
-            values.AddNvValue("sourcePath","String",apexChunk.GetVariableByName("importFile").ToString());
-            values.AddNvValue("authorName","String",Environment.UserName);
-            values.AddNvValue("lastModified","String",((CDateTime)apexChunk.GetVariableByName("importFileTimeStamp")).Date.ToString("f"));
+            values.AddNvValue("fileVersion", "String", fileVersion);
+            values.AddNvValue("toolVersion","String", toolVersion);
+            values.AddNvValue("sourcePath", "String", apexChunk.GetVariableByName("importFile").ToString());
+            values.AddNvValue("authorName", "String", authorName);
+            values.AddNvValue("lastModified", "String", ((CDateTime)apexChunk.GetVariableByName("importFileTimeStamp")).Date.ToString("f"));
             HairWorksInfo.Add(values);
             return HairWorksInfo;
         }

--- a/WolvenKit.CR2W/Types/CDateTime.cs
+++ b/WolvenKit.CR2W/Types/CDateTime.cs
@@ -34,7 +34,7 @@ namespace WolvenKit.CR2W.Types
                 if (Date <= DateTime.MinValue)
                     Date = new DateTime(2015,5,19,0,0,0,0);
             }
-            catch (ArgumentOutOfRangeException e)
+            catch (ArgumentOutOfRangeException)
             {
                 Date = new DateTime(2015,5,19,0,0,0,0);
             }

--- a/WolvenKit.sln
+++ b/WolvenKit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WolvenKit", "WolvenKit\WolvenKit.csproj", "{12FD792B-EC76-4969-8B42-9671025D5108}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/WolvenKit.sln
+++ b/WolvenKit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WolvenKit", "WolvenKit\WolvenKit.csproj", "{12FD792B-EC76-4969-8B42-9671025D5108}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/WolvenKit/DDSUtility.cs
+++ b/WolvenKit/DDSUtility.cs
@@ -9,6 +9,9 @@ namespace WolvenKit
     /// </DDSUtility>
     class DDSUtility
     {
+        // Disable warning for never assigned to variables in structs.
+        #pragma warning disable 0649
+
         #region DDS Structs
         // Structs to define the header of a dds image file
 
@@ -50,7 +53,7 @@ namespace WolvenKit
             public uint caps4;
         }
         #endregion
-        
+
         #region CSwfTexture Struct
         //The embedded image file inside the CSwfTexture var
         //has some small header which is just 7 Uint32 vars
@@ -67,7 +70,9 @@ namespace WolvenKit
             public uint Unknown7;   //No idea
         }
         #endregion
-        
+
+        #pragma warning restore 0649
+
         /// <ExportAsDDS>
         /// This method converts a byte array from the CR2W to a dds format byte array
         /// This should only be used when exporting from a CSwfTexture var (swfTexture).

--- a/WolvenKit/Forms/frmCreateInstaller.cs
+++ b/WolvenKit/Forms/frmCreateInstaller.cs
@@ -35,7 +35,7 @@ namespace WolvenKit.Forms
             {
                 if (sf.ShowDialog() == DialogResult.OK)
                 {
-                    CreatePackage(sf.FileName);
+                    Task.Run(() => CreatePackage(sf.FileName));
                 }
             }
         }

--- a/WolvenKit/Forms/frmMain.cs
+++ b/WolvenKit/Forms/frmMain.cs
@@ -1120,7 +1120,7 @@ _col - for simple stuff like boxes and spheres","Information about importing mod
                         sf.InitialDirectory = MainController.Get().Configuration.InitialFileDirectory;
                         if (sf.ShowDialog() == DialogResult.OK)
                         {
-                            ImportFile(of.FileName, sf.FileName);
+                            Task.Run(() => ImportFile(of.FileName, sf.FileName));
                         }
                     }
                 }
@@ -1140,8 +1140,8 @@ _col - for simple stuff like boxes and spheres","Information about importing mod
                         sf.Description = "Please specify a location to save the dumped file";
                         if (sf.ShowDialog() == DialogResult.OK)
                         {
-                            DumpFile(of.SelectedPath.EndsWith("\\") ? of.SelectedPath : of.SelectedPath + "\\",
-                                sf.SelectedPath.EndsWith("\\") ? sf.SelectedPath : sf.SelectedPath + "\\");
+                            Task.Run(() => DumpFile(of.SelectedPath.EndsWith("\\") ? of.SelectedPath : of.SelectedPath + "\\",
+                                sf.SelectedPath.EndsWith("\\") ? sf.SelectedPath : sf.SelectedPath + "\\"));
                         }
                     }
                 }
@@ -1163,7 +1163,7 @@ _col - for simple stuff like boxes and spheres","Information about importing mod
                         sf.InitialDirectory = MainController.Get().Configuration.InitialFileDirectory;
                         if (sf.ShowDialog() == DialogResult.OK)
                         {
-                            ImportFile(of.FileName, sf.FileName);
+                            Task.Run(() => ImportFile(of.FileName, sf.FileName));
                         }
                     }
                 }
@@ -1461,7 +1461,7 @@ _col - for simple stuff like boxes and spheres","Information about importing mod
                             if (File.Exists(oldmod.FileName))
                                 File.Delete(oldmod.FileName);
                         }
-                        catch (System.IO.IOException exception)
+                        catch (IOException)
                         {
                             MessageBox.Show("Sorry but there already exist a folder/mod with that name.","Error",MessageBoxButtons.OK,MessageBoxIcon.Error);
                             return;

--- a/WolvenKit/MainController.cs
+++ b/WolvenKit/MainController.cs
@@ -166,7 +166,7 @@ namespace WolvenKit
         /// Initializes the archive managers in an async thread
         /// </summary>
         /// <returns></returns>
-        public async Task Initialize()
+        public void Initialize()
         {
             try
             {
@@ -196,7 +196,7 @@ namespace WolvenKit
                             }
                         }
                     }
-                    catch (System.Exception ex)
+                    catch (Exception)
                     {
                         if (File.Exists(Path.Combine(ManagerCacheDir, "string_cache.bin")))
                             File.Delete(Path.Combine(ManagerCacheDir, "string_cache.bin"));
@@ -353,7 +353,7 @@ namespace WolvenKit
 
                 mainController.Loaded = true;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 mainController.Loaded = false;
             }

--- a/WolvenKit/discord.cs
+++ b/WolvenKit/discord.cs
@@ -9,6 +9,9 @@ namespace SharpPresence
 {
     class Discord
     {
+        // Disable warning for never assigned to variables in structs.
+        #pragma warning disable 0649
+
         public struct EventHandlers
         {
             public IntPtr ready;
@@ -49,6 +52,7 @@ namespace SharpPresence
             public string avatar;
         }
 
+        #pragma warning restore 0649
         //--------------------------------------------------------------------------------
 
         public enum Reply : int


### PR DESCRIPTION
Added Task.Run() to each async task that was being called. Added a disable warning for unassigned variables within structs. Removed variables from exception catches. Removed async from Initialize, as it is already starting a seperate task.

# <PULL REQUEST TITLE>

Implemented:
- <Features implemented>

Fixed:
- <Fixes>Compiler warnings.

<Aditional notes>
   