### PR TITLE
Basic XML Dump beutified and context menu fixed

### DIFF
--- a/WolvenKit.CR2W/CR2W/CR2WFile.cs
+++ b/WolvenKit.CR2W/CR2W/CR2WFile.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using System.Collections.Generic;
+using System.Xml;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -582,7 +583,13 @@ namespace WolvenKit.CR2W
         #region Supporting Functions
         public void SerializeToXml(Stream writer)
         {
-            using (System.Xml.XmlWriter xw = System.Xml.XmlWriter.Create(writer))
+            var settings = new XmlWriterSettings()
+            {
+                Indent = true,
+                IndentChars = "\t",
+                NewLineOnAttributes = true
+            };
+            using (XmlWriter xw = XmlWriter.Create(writer, settings))
             {
                 XmlSerializer.SerializeStartObject<CR2WFile>(xw, this);
 

--- a/WolvenKit/Forms/frmModExplorer.cs
+++ b/WolvenKit/Forms/frmModExplorer.cs
@@ -250,10 +250,12 @@ namespace WolvenKit
         private void contextMenu_Opened(object sender, EventArgs e)
         {
             var selectedNode = modFileList.SelectedNode;
+            string ext = "";
+
             if (selectedNode != null)
             {
                 var fi = new FileInfo(selectedNode.FullPath);
-                var ext = fi.Extension.TrimStart('.');
+                ext = fi.Extension.TrimStart('.');
 
                 bool isbundle = Path.Combine(ActiveMod.FileDirectory, fi.ToString()).Contains(Path.Combine(ActiveMod.ModDirectory, new Bundle().TypeName));
                 bool israw = Path.Combine(ActiveMod.FileDirectory, fi.ToString()).Contains(Path.Combine(ActiveMod.FileDirectory, "Raw"));
@@ -280,7 +282,7 @@ namespace WolvenKit
             copyToolStripMenuItem.Enabled = modFileList.SelectedNode != null;
             
             showFileInExplorerToolStripMenuItem.Enabled = modFileList.SelectedNode != null;
-            dumpXMLToolStripMenuItem.Enabled = modFileList.SelectedNode != null;
+            dumpXMLToolStripMenuItem.Enabled = modFileList.SelectedNode != null && ext != "xml" && ext != "csv" && ext != "ws" && ext != "";
 
         }
 


### PR DESCRIPTION
# 145: Basic XML Dump beautified and context menu fixed

Implemented:
- Bautified original xml dump

Fixed:
- context XML Dump menu is disabled when file is either: xml, csv, ws or is directory.

<Additional notes>
Context menu enable/disable requires fixing for other options as well.
