### PR TITLE
Release 0.5 Hotfixes

### DIFF
--- a/CR2WTests/StressTest.cs
+++ b/CR2WTests/StressTest.cs
@@ -57,21 +57,19 @@ namespace CR2WTests
         [ClassInitialize]
         public static void Setup(TestContext context)
         {
-            mmfs = new Dictionary<string, MemoryMappedFile>();
+            //mmfs = new Dictionary<string, MemoryMappedFile>();
             mc = new BundleManager();
             //mc.LoadAll("D:\\SteamLibrary\\steamapps\\common\\The Witcher 3\\bin\\x64");
             mc.LoadAll("C:\\Steam\\steamapps\\common\\The Witcher 3\\bin\\x64");
 
-            // Load MemoryMapped Bundles
-            foreach (var b in mc.Bundles.Values)
-            {
-                var e = b.FileName.GetHashMD5();
+            //// Load MemoryMapped Bundles
+            //foreach (var b in mc.Bundles.Values)
+            //{
+            //    var e = b.FileName.GetHashMD5();
 
-                mmfs.Add(e, MemoryMappedFile.CreateFromFile(b.FileName, FileMode.Open, e, 0, MemoryMappedFileAccess.Read));
+            //    mmfs.Add(e, MemoryMappedFile.CreateFromFile(b.FileName, FileMode.Open, e, 0, MemoryMappedFileAccess.Read));
 
-            }
-
-
+            //}
         }
 
         // Methods to test for the different file types

--- a/WolvenKit.Bundles/BundleItem.cs
+++ b/WolvenKit.Bundles/BundleItem.cs
@@ -50,57 +50,54 @@ namespace WolvenKit.Bundles
 
         public void Extract(Stream output)
         {
-            var hash = Bundle.FileName.GetHashMD5();
-            using (MemoryMappedFile mmf = MemoryMappedFile.OpenExisting(hash, MemoryMappedFileRights.Read))
+            using (var file = MemoryMappedFile.CreateFromFile(Bundle.FileName, FileMode.Open))
+            using (var viewstream = file.CreateViewStream(PageOFfset, ZSize, MemoryMappedFileAccess.Read))
             {
-                using (var viewstream = mmf.CreateViewStream(PageOFfset, ZSize, MemoryMappedFileAccess.Read))
+                switch (CompressionType)
                 {
-                    switch (CompressionType)
+                    case "None":
                     {
-                        case "None":
-                        {
-                            viewstream.CopyTo(output);
-                            break;
-                        }
-                        case "Lz4":
-                        {
-                            var buffer = new byte[ZSize];
-                            var c = viewstream.Read(buffer, 0, buffer.Length);
-                            var uncompressed = LZ4Codec.Decode(buffer, 0, c, (int) Size);
-                            output.Write(uncompressed, 0, uncompressed.Length);
-                            break;
-                        }
-                        case "Snappy":
-                        {
-                            var buffer = new byte[ZSize];
-                            var c = viewstream.Read(buffer, 0, buffer.Length);
-                            var uncompressed = SnappyCodec.Uncompress(buffer);
-                            output.Write(uncompressed,0,uncompressed.Length);
-                            break;
-                        }
-                        case "Doboz":
-                        {
-                            var buffer = new byte[ZSize];
-                            var c = viewstream.Read(buffer, 0, buffer.Length);
-                            var uncompressed = DobozCodec.Decode(buffer, 0, c);
-                            output.Write(uncompressed, 0, uncompressed.Length);
-                            break;
-                        }
-                        case "Zlib":
-                        {
-                            var zlib = new ZlibStream(viewstream, CompressionMode.Decompress);
-                            zlib.CopyTo(output);
-                            break;
-                        }
-                        default:
-                            throw new MissingCompressionException("Unhandled compression algorithm.")
-                            {
-                                Compression = Compression
-                            };
+                        viewstream.CopyTo(output);
+                        break;
                     }
-
-                    viewstream.Close();
+                    case "Lz4":
+                    {
+                        var buffer = new byte[ZSize];
+                        var c = viewstream.Read(buffer, 0, buffer.Length);
+                        var uncompressed = LZ4Codec.Decode(buffer, 0, c, (int) Size);
+                        output.Write(uncompressed, 0, uncompressed.Length);
+                        break;
+                    }
+                    case "Snappy":
+                    {
+                        var buffer = new byte[ZSize];
+                        var c = viewstream.Read(buffer, 0, buffer.Length);
+                        var uncompressed = SnappyCodec.Uncompress(buffer);
+                        output.Write(uncompressed,0,uncompressed.Length);
+                        break;
+                    }
+                    case "Doboz":
+                    {
+                        var buffer = new byte[ZSize];
+                        var c = viewstream.Read(buffer, 0, buffer.Length);
+                        var uncompressed = DobozCodec.Decode(buffer, 0, c);
+                        output.Write(uncompressed, 0, uncompressed.Length);
+                        break;
+                    }
+                    case "Zlib":
+                    {
+                        var zlib = new ZlibStream(viewstream, CompressionMode.Decompress);
+                        zlib.CopyTo(output);
+                        break;
+                    }
+                    default:
+                        throw new MissingCompressionException("Unhandled compression algorithm.")
+                        {
+                            Compression = Compression
+                        };
                 }
+
+                viewstream.Close();
             }
         }
 

--- a/WolvenKit.CR2W/CR2W/CR2WBuffer.cs
+++ b/WolvenKit.CR2W/CR2W/CR2WBuffer.cs
@@ -59,13 +59,12 @@ namespace WolvenKit.CR2W
 
         public void WriteData(BinaryWriter file)
         {
-            // there is no Data to write
-            /*_buffer.offset = (uint) file.BaseStream.Position;
+            _buffer.offset = (uint) file.BaseStream.Position;
             if (Data != null)
             {
                 file.Write(Data);
                 _buffer.memSize = (uint)Data.Length;
-            }*/
+            }
             
         }
 

--- a/WolvenKit.CR2W/CR2W/CR2WFile.cs
+++ b/WolvenKit.CR2W/CR2W/CR2WFile.cs
@@ -133,7 +133,8 @@ namespace WolvenKit.CR2W
             var dt = new CDateTime(m_fileheader.timeStamp);
 
             m_tableheaders = ReadStructs<CR2WTable>(10);
-            
+            m_hasInternalBuffer = m_fileheader.bufferSize > m_fileheader.fileSize;
+
             // read strings
             m_strings = ReadStringsBuffer();
             
@@ -157,9 +158,12 @@ namespace WolvenKit.CR2W
                 chunk.ReadData(file);
             }
             // Read buffer data //block 6
-            foreach (var buffer in buffers)
+            if (m_hasInternalBuffer)
             {
-                //buffer.ReadData(file);
+                foreach (var buffer in buffers)
+                {
+                    buffer.ReadData(file);
+                }
             }
             // Read embedded files //block 7
             foreach (var emb in embedded)
@@ -169,17 +173,17 @@ namespace WolvenKit.CR2W
             #endregion
 
             //this never actually triggers?
-            /*#region Read Buffer
-            file.BaseStream.Seek(m_fileheader.fileSize, SeekOrigin.Begin);
-            m_hasInternalBuffer = m_fileheader.bufferSize > m_fileheader.fileSize;
-            byte[] bufferdata;
-            var actualbuffersize = (int)(m_fileheader.bufferSize - m_fileheader.fileSize);
-            if (actualbuffersize > 0)
-            {
-                bufferdata = new byte[actualbuffersize];
-                file.BaseStream.Read(bufferdata, 0, actualbuffersize);
-            }
-            #endregion*/
+            //#region Read Buffer
+            //file.BaseStream.Seek(m_fileheader.fileSize, SeekOrigin.Begin);
+            //m_hasInternalBuffer = m_fileheader.bufferSize > m_fileheader.fileSize;
+            //byte[] bufferdata;
+            //var actualbuffersize = (int)(m_fileheader.bufferSize - m_fileheader.fileSize);
+            //if (actualbuffersize > 0)
+            //{
+            //    bufferdata = new byte[actualbuffersize];
+            //    file.BaseStream.Read(bufferdata, 0, actualbuffersize);
+            //}
+            //#endregion
 
             //dbg++
             //(var nameslist, var importslist) = GenerateStringtable();
@@ -426,6 +430,11 @@ namespace WolvenKit.CR2W
             {
                 var newoffset = chunks[i].Export.dataOffset + headerOffset;
                 chunks[i].SetOffset(newoffset);
+            }
+            for (var i = 0; i < buffers.Count; i++)
+            {
+                var newoffset = buffers[i].Buffer.offset + headerOffset;
+                buffers[i].SetOffset(newoffset);
             }
             for (var i = 0; i < embedded.Count; i++)
             {

--- a/WolvenKit.Common/Wcc/enums.cs
+++ b/WolvenKit.Common/Wcc/enums.cs
@@ -38,10 +38,11 @@ namespace WolvenKit.Common.Wcc
                 case ".bmp": 
                 case ".jpg": 
                 case ".tga": 
-                case ".dds": 
+                case ".dds":
+                    return "TextureCache";
                 case ".re": 
                 case ".fbx": 
-                    return "TextureCache";
+                    return "Uncooked";
                 default: return "";
             }
         }

--- a/WolvenKit/Forms/frmAbout.cs
+++ b/WolvenKit/Forms/frmAbout.cs
@@ -17,8 +17,7 @@ namespace WolvenKit
             labelCompanyName.Text = AssemblyTrademark;
             
             webBrowser1.DocumentText = $@"
-<
->
+
     <body bgcolor={ColorTranslator.ToHtml(SystemColors.Control)}>
         <center>
         <h3>Credits</h3> <br>   
@@ -28,6 +27,8 @@ namespace WolvenKit
         Nightingale<br>
         (Major reverse enginering)<br><br> 
         Murzinio<br>
+        (Programming)<br><br> 
+        rfuzzo<br>
         (Programming)<br><br> 
         <br><br>
         <b>Based on the code from {"\"Sarcen's Witcher 3 Mod Editor\""} by Sarcen </b><br>
@@ -39,7 +40,7 @@ namespace WolvenKit
         Cthulhu<br>
         <center>
     <body>
-</html>";
+";
         }
 
         #region Assembly Attribute Accessors

--- a/WolvenKit/Forms/frmImportUtility.Designer.cs
+++ b/WolvenKit/Forms/frmImportUtility.Designer.cs
@@ -62,15 +62,14 @@
             this.olvColumnImportType,
             this.olvColumnTexturegroup});
             this.objectListView.Cursor = System.Windows.Forms.Cursors.Default;
-            this.objectListView.GridLines = true;
             this.objectListView.HasCollapsibleGroups = false;
-            this.objectListView.HeaderUsesThemes = true;
             this.objectListView.HideSelection = false;
             this.objectListView.Location = new System.Drawing.Point(0, 28);
             this.objectListView.Name = "objectListView";
             this.objectListView.ShowGroups = false;
             this.objectListView.Size = new System.Drawing.Size(800, 422);
             this.objectListView.TabIndex = 0;
+            this.objectListView.UseAlternatingBackColors = true;
             this.objectListView.UseCompatibleStateImageBehavior = false;
             this.objectListView.View = System.Windows.Forms.View.Details;
             this.objectListView.CellEditFinished += new BrightIdeasSoftware.CellEditEventHandler(this.objectListView_CellEditFinished);
@@ -101,6 +100,7 @@
             // olvColumnTexturegroup
             // 
             this.olvColumnTexturegroup.AspectName = "Texturegroup";
+            this.olvColumnTexturegroup.FillsFreeSpace = true;
             this.olvColumnTexturegroup.Groupable = false;
             this.olvColumnTexturegroup.Text = "Texturegroup";
             this.olvColumnTexturegroup.Width = 150;

--- a/WolvenKit/Forms/frmImportUtility.cs
+++ b/WolvenKit/Forms/frmImportUtility.cs
@@ -43,13 +43,12 @@ namespace WolvenKit.Forms
         public void ApplyCustomTheme()
         {
             var theme = MainController.Get().GetTheme();
-
             MainController.Get().ToolStripExtender.SetStyle(toolStrip, VisualStudioToolStripExtender.VsVersion.Vs2015, theme);
 
             this.objectListView.BackColor = theme.ColorPalette.ToolWindowTabSelectedInactive.Background;
             this.objectListView.AlternateRowBackColor = theme.ColorPalette.OverflowButtonHovered.Background;
 
-            this.objectListView.ForeColor = theme.ColorPalette.CommandBarMenuDefault.Text;
+            this.objectListView.ForeColor = Color.Black;
             HeaderFormatStyle hfs = new HeaderFormatStyle()
             {
                 Normal = new HeaderStateStyle()
@@ -72,7 +71,6 @@ namespace WolvenKit.Forms
             objectListView.UnfocusedSelectedBackColor = theme.ColorPalette.CommandBarToolbarButtonPressed.Background;
         }
 
-        
 
         internal class XBMDump
         {

--- a/WolvenKit/Forms/frmMain.cs
+++ b/WolvenKit/Forms/frmMain.cs
@@ -171,132 +171,17 @@ namespace WolvenKit
             this.dockPanel.Theme = theme;
             visualStudioToolStripExtender1.SetStyle(menuStrip1, VisualStudioToolStripExtender.VsVersion.Vs2015, theme);
             visualStudioToolStripExtender1.SetStyle(toolbarToolStrip, VisualStudioToolStripExtender.VsVersion.Vs2015, theme);
-            //visualStudioToolStripExtender1.SetStyle(statusToolStrip, VisualStudioToolStripExtender.VsVersion.Vs2015, theme);
         }
-        /// <summary>
-        /// https://stackoverflow.com/questions/29024910/how-to-design-a-custom-close-minimize-and-maximize-button-in-windows-form-appli/29025094
-        /// https://social.msdn.microsoft.com/Forums/windows/en-US/5e288892-784a-4636-a63d-c2aad58ec097/aerosnap-when-form-border-style-is-set-to-none?forum=winforms
-        /// 
-        /// </summary>
-        private struct RECT
-        {
-            public int left, top, right, bottom;
 
-            public RECT(Rectangle rc)
-            {
-                this.left = rc.Left;
-                this.top = rc.Top;
-                this.right = rc.Right;
-                this.bottom = rc.Bottom;
-            }
+        #region UI formborderstyle none
 
-            public Rectangle ToRectangle()
-            {
-                return Rectangle.FromLTRB(left, top, right, bottom);
-            }
-
-        }
-        private struct NCCALCSIZE_PARAMS
-        {
-            public RECT rgrc0, rgrc1, rgrc2;
-            public WINDOWPOS lppos;
-        }
-        private struct WINDOWPOS
-        {
-            public IntPtr hWnd, hWndInsertAfter;
-            public int x, y, cx, cy, flags;
-        }
-        const uint WM_NCHITTEST = 0x0084, WM_MOUSEMOVE = 0x0200,
-                 HTLEFT = 10, HTRIGHT = 11, HTBOTTOMRIGHT = 17,
-                 HTBOTTOM = 15, HTBOTTOMLEFT = 16, HTTOP = 12,
-                 HTTOPLEFT = 13, HTTOPRIGHT = 14;
-        
-        protected override void WndProc(ref Message m)
-        {
-            /*const int WM_NCCALCSIZE = 0x83;
-            if (m.Msg == WM_NCCALCSIZE)
-            {
-                if (m.WParam.Equals(IntPtr.Zero))
-                {
-                    RECT rc = (RECT)m.GetLParam(typeof(RECT));
-                    Rectangle r = rc.ToRectangle();
-                    r.Inflate(8, 8);
-                    System.Runtime.InteropServices.Marshal.StructureToPtr(new RECT(r), m.LParam, true);
-                }
-                else
-                {
-                    NCCALCSIZE_PARAMS csp = (NCCALCSIZE_PARAMS)m.GetLParam(typeof(NCCALCSIZE_PARAMS));
-                    Rectangle r = csp.rgrc0.ToRectangle();
-                    r.Inflate(8, 8);
-                    csp.rgrc0 = new RECT(r);
-                    System.Runtime.InteropServices.Marshal.StructureToPtr(csp, m.LParam, true);
-                }
-                m.Result = IntPtr.Zero;
-            }*/
-
-            if (m.Msg == WM_NCHITTEST)
-            {
-                Point screenPoint = new Point(m.LParam.ToInt32());
-                Point clientPoint = this.PointToClient(screenPoint);
-                bool bTop = (clientPoint.Y < 4);
-                bool bLeft = (clientPoint.X < 4);
-                bool bRight = (clientPoint.X > this.ClientSize.Width - 4);
-                bool bBottom = (clientPoint.Y > this.ClientSize.Height - 4);
-
-
-                bool bCaption = (clientPoint.Y > 3
-                    && clientPoint.Y < SystemInformation.CaptionHeight
-                    && clientPoint.X < this.ClientSize.Width - 3
-                    && clientPoint.X > 3);
-
-                if (bCaption)
-                {
-                    m.Result = (IntPtr)HTCAPTION;
-                    return;
-                }
-                else if (bBottom && bLeft)
-                {
-                    m.Result = (IntPtr)HTBOTTOMLEFT;
-                    return;
-                }
-                else if (bBottom && bRight)
-                {
-                    m.Result = (IntPtr)HTBOTTOMRIGHT;
-                    return;
-                }
-                else if (bTop && bLeft)
-                {
-                    m.Result = (IntPtr)HTTOPLEFT;
-                    return;
-                }
-                else if (bTop && bRight)
-                {
-                    m.Result = (IntPtr)HTTOPRIGHT;
-                    return;
-                }
-                else if (bLeft)
-                {
-                    m.Result = (IntPtr)HTLEFT;
-                    return;
-                }
-                else if (bTop)
-                {
-                    m.Result = (IntPtr)HTTOP;
-                    return;
-                }
-                else if (bRight)
-                {
-                    m.Result = (IntPtr)HTRIGHT;
-                    return;
-                }
-                else if (bBottom)
-                {
-                    m.Result = (IntPtr)HTBOTTOM;
-                    return;
-                }
-            }
-            base.WndProc(ref m);
-        }
+        private const long WS_SYSMENU = 0x00080000L;
+        private const long WS_BORDER = 0x00800000L;
+        private const long WS_SIZEBOX = 0x00040000L;
+        private const long WS_CHILD = 0x40000000L;
+        private const long WS_DLGFRAME = 0x00400000L;
+        private const long WS_MAXIMIZEBOX = 0x00010000L;
+        private const long WS_CAPTION = 0x00C00000L;
 
         protected override CreateParams CreateParams
         {
@@ -304,17 +189,26 @@ namespace WolvenKit
             {
                 CreateParams cp = base.CreateParams;
                 {
-                    //cp.Style = (int)0x00040000L; //WS_SIZEBOX
-                    //cp.Style |= (int)0x00080000L; //WS_SYSMENU
-                    //cp.Style &= ~(int)0x00040000L;
-
-                    cp.Style = (int)0x00800000L; //WS_BORDER
-                    //cp.Style |= (int)0x00080000L | (int)0x00800000L | (int)0x00040000L; //aerosnap
-                    
+                    cp.Style |= (int)WS_BORDER;
+                    cp.Style |= (int)WS_SYSMENU;
+                    cp.Style |= (int)WS_SIZEBOX;                    
                 }
                 return cp;
             }
         }
+        private void MinimizeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            WindowState = FormWindowState.Minimized;
+        }
+
+        private void RestoreToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (this.WindowState != FormWindowState.Maximized)
+                WindowState = FormWindowState.Maximized;
+            else
+                WindowState = FormWindowState.Normal;
+        }
+        #endregion
 
         private void LoggerUpdated(object sender, PropertyChangedEventArgs e)
         {
@@ -1118,6 +1012,8 @@ namespace WolvenKit
             Output = null;
             Console?.Close();
             Console = null;
+            ImportUtility?.Close();
+            ImportUtility = null;
             foreach (var window in dockPanel.FloatWindows.ToList())
                 window.Dispose();
         }
@@ -1140,6 +1036,7 @@ namespace WolvenKit
             ShowModExplorer();
             ShowConsole();
             ShowOutput();
+            ShowImportUtility();
         }
 
         private void ShowModExplorer()
@@ -1691,7 +1588,7 @@ _col - for simple stuff like boxes and spheres","Information about importing mod
                 dir = Path.GetDirectoryName(fullpath);
             else
                 dir = fullpath;
-            string reldir = dir.TrimStart(ActiveMod.FileDirectory);
+            string reldir = dir.TrimStart(ActiveMod.FileDirectory).TrimStart(Path.DirectorySeparatorChar);
 
             // Trim working directories in path
             var reg = new Regex(@"^(Raw|Mod)\\(.*)");
@@ -1703,6 +1600,10 @@ _col - for simple stuff like boxes and spheres","Information about importing mod
             if (match.Success)
                 reldir = match.Groups[2].Value;
             reg = new Regex(@"^(TextureCache)\\(.*)");
+            match = reg.Match(reldir);
+            if (match.Success)
+                reldir = match.Groups[2].Value;
+            reg = new Regex(@"^(Uncooked)\\(.*)");
             match = reg.Match(reldir);
             if (match.Success)
                 reldir = match.Groups[2].Value;
@@ -2276,30 +2177,6 @@ Would you like to open the problem steps recorder?", "Bug reporting", MessageBox
                         CR2WVerify.VerifyFile(f);
                     }
                 }
-            }
-        }
-
-        private void MinimizeToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            WindowState = FormWindowState.Minimized;
-        }
-
-        private void RestoreToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Screen screen = Screen.FromControl(this);
-            int x = screen.WorkingArea.X - screen.Bounds.X;
-            int y = screen.WorkingArea.Y - screen.Bounds.Y;
-            this.MaximizedBounds = new Rectangle(x, y,
-                screen.WorkingArea.Width, screen.WorkingArea.Height);
-            this.MaximumSize = screen.WorkingArea.Size;
-
-            if (this.WindowState != FormWindowState.Maximized)
-            {
-                WindowState = FormWindowState.Maximized;
-            }
-            else
-            {
-                WindowState = FormWindowState.Normal;
             }
         }
 

--- a/WolvenKit/MainController.cs
+++ b/WolvenKit/MainController.cs
@@ -228,7 +228,7 @@ namespace WolvenKit
                     {
                         if (File.Exists(Path.Combine(ManagerCacheDir, "string_cache.bin")) && new FileInfo(Path.Combine(ManagerCacheDir, "string_cache.bin")).Length > 0)
                         {
-                            using (var file = File.Open(Path.Combine(ManagerCacheDir, "string_cache.bin"),FileMode.Open))
+                            using (var file = File.Open(Path.Combine(ManagerCacheDir, "string_cache.bin"), FileMode.Open))
                             {
                                 w3StringManager = ProtoBuf.Serializer.Deserialize<W3StringManager>(file);
                             }
@@ -238,9 +238,9 @@ namespace WolvenKit
                             w3StringManager = new W3StringManager();
                             w3StringManager.Load(Configuration.TextLanguage, Path.GetDirectoryName(Configuration.ExecutablePath));
                             Directory.CreateDirectory(ManagerCacheDir);
-                            using (var file = File.Open(Path.Combine(ManagerCacheDir, "string_cache.bin"),FileMode.Create))
+                            using (var file = File.Open(Path.Combine(ManagerCacheDir, "string_cache.bin"), FileMode.Create))
                             {
-                                ProtoBuf.Serializer.Serialize(file,w3StringManager);
+                                ProtoBuf.Serializer.Serialize(file, w3StringManager);
                             }
                         }
                     }

--- a/WolvenKit/MainController.cs
+++ b/WolvenKit/MainController.cs
@@ -126,7 +126,7 @@ namespace WolvenKit
         public CollisionManager CollisionManager => collisionManager;
         public SpeechManager SpeechManager => speechManager;
 
-        public Dictionary<string, MemoryMappedFile> mmfs = new Dictionary<string, MemoryMappedFile>();
+        //public Dictionary<string, MemoryMappedFile> mmfs = new Dictionary<string, MemoryMappedFile>();
         #endregion
 
         /// <summary>
@@ -479,19 +479,19 @@ namespace WolvenKit
                     }
                     Cr2wResourceManager.Get().WriteVanilla();
                 }
-                
+
                 #endregion
 
-                #region MMFUtil
-                loadStatus = "Loading MemoryMappedFile manager!";
-                foreach (var b in BundleManager.Bundles.Values)
-                {
-                    var hash = b.FileName.GetHashMD5();
+                //#region MMFUtil
+                //loadStatus = "Loading MemoryMappedFile manager!";
+                //foreach (var b in BundleManager.Bundles.Values)
+                //{
+                //    var hash = b.FileName.GetHashMD5();
 
-                    mmfs.Add(hash, MemoryMappedFile.CreateFromFile(b.FileName, FileMode.Open, hash, 0, MemoryMappedFileAccess.Read));
+                //    mmfs.Add(hash, MemoryMappedFile.CreateFromFile(b.FileName, FileMode.Open, hash, 0, MemoryMappedFileAccess.Read));
 
-                }
-                #endregion
+                //}
+                //#endregion
 
                 loadStatus = "Loaded";
 

--- a/WolvenKit/Properties/AssemblyInfo.cs
+++ b/WolvenKit/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Community")]
 [assembly: AssemblyProduct("Wolven kit")]
-[assembly: AssemblyCopyright("Copyright © 2015-2017")]
+[assembly: AssemblyCopyright("Copyright © 2015-2020")]
 [assembly: AssemblyTrademark("GPL-3.0")]
 [assembly: AssemblyCulture("")]
 
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.3.1.0")]
-[assembly: AssemblyFileVersion("0.3.1.0")]
+[assembly: AssemblyVersion("0.5.0.1")]
+[assembly: AssemblyFileVersion("0.5.0.1")]


### PR DESCRIPTION
# Release 0.5 Hotfixes

- updated the assmembly version

Implemented:
- readded areosnap at the cost of a white menu strip
- import utility themeing

Fixed:
- fixed two inconsistencies in raw file importing
- fixed a bug where saving uncooked files would not write buffer data
- fixed a bug whith the import utility crashing on theme change
- fixed an issue that prevented the game from launching while Wkit is running

<Additional notes>
