### PR TITLE
Menu creator fix: load XML file into string prior to parsing, which avoids exception when file is wrongly labelled as "utf-16".

### DIFF
--- a/WolvenKit/Forms/frmMenuCreator.cs
+++ b/WolvenKit/Forms/frmMenuCreator.cs
@@ -98,7 +98,7 @@ namespace WolvenKit
                 };
                 if (of.ShowDialog() == DialogResult.OK)
                 {
-                    var loadedxml = XDocument.Load(of.FileName);
+                    var loadedxml = XDocument.Parse(System.IO.File.ReadAllText(of.FileName));
                     MenuObject.Groups = loadedxml.Root?.Elements("Group").Select(DeserializeGroup).ToList();
                     PaintMenuTree();
                 }


### PR DESCRIPTION
# Menu Creator: Quick fix that enables loading modded menus with incorrectly specified encoding.

Fixed:
- Menu Creator: I was unable to load any XML menus provided by mods, due to exception: "There is no Unicode byte-mark."  These modded menus specified their encoding as "utf-16", when the files were actually "utf-8".  I imagine this is because the authors copied the encoding line from CDPR, but didn't actually save the files as UTF-16.  

I have worked around this issue by loading the XML file into a string, then passing that to XDocument.Parse, which I assume bypasses the encoding checking.