### PR TITLE
Bugfix: avoid exceptions when mod project is opened

### DIFF
--- a/WolvenKit/Forms/frmCR2WtoText.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.cs
@@ -721,7 +721,8 @@ namespace WolvenKit.Forms
                 {
                     try
                     {
-                        CR2WFile embedcr2w = new CR2WFile(((IByteSource)node.Variable).Bytes, MainController.Get().Logger);
+                        var ls = new LoggerService();
+                        CR2WFile embedcr2w = new CR2WFile( ((IByteSource)node.Variable).Bytes, ls );
                         var lc = new LoggerCR2W(embedcr2w, Writer, Options);
                         lc.processCR2W(level);
                     }


### PR DESCRIPTION
# Bugfix for Dump CR2W Files To Text

Fixed:
- Avoid exceptions when mod project is open while Dump CR2W Text is running by creating a new dummy LoggerService rather than re-using the one on MainController.