### PR TITLE
Dump CR2W To Text Localized Strings

### DIFF
--- a/WolvenKit/Forms/frmCR2WtoText.Designer.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.Designer.cs
@@ -67,6 +67,7 @@
             this.colSkipped = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colExceptions = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.txtLog = new System.Windows.Forms.TextBox();
+            this.chkLocalizedString = new System.Windows.Forms.CheckBox();
             this.pnlControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numThreads)).BeginInit();
             this.grpExistingFiles.SuspendLayout();
@@ -80,7 +81,7 @@
             this.btnRun.Enabled = false;
             this.btnRun.Image = global::WolvenKit.Properties.Resources.Output_16x;
             this.btnRun.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnRun.Location = new System.Drawing.Point(195, 494);
+            this.btnRun.Location = new System.Drawing.Point(195, 514);
             this.btnRun.Name = "btnRun";
             this.btnRun.Size = new System.Drawing.Size(420, 23);
             this.btnRun.TabIndex = 30;
@@ -105,6 +106,7 @@
             // 
             // pnlControls
             // 
+            this.pnlControls.Controls.Add(this.chkLocalizedString);
             this.pnlControls.Controls.Add(this.labNumThreads);
             this.pnlControls.Controls.Add(this.numThreads);
             this.pnlControls.Controls.Add(this.chkCreateFolders);
@@ -125,7 +127,7 @@
             this.pnlControls.Controls.Add(this.grpRadioOutputMode);
             this.pnlControls.Location = new System.Drawing.Point(12, 192);
             this.pnlControls.Name = "pnlControls";
-            this.pnlControls.Size = new System.Drawing.Size(740, 295);
+            this.pnlControls.Size = new System.Drawing.Size(740, 314);
             this.pnlControls.TabIndex = 21;
             // 
             // labNumThreads
@@ -183,7 +185,7 @@
             // 
             this.grpExistingFiles.Controls.Add(this.radExistingSkip);
             this.grpExistingFiles.Controls.Add(this.radExistingOverwrite);
-            this.grpExistingFiles.Location = new System.Drawing.Point(144, 229);
+            this.grpExistingFiles.Location = new System.Drawing.Point(144, 255);
             this.grpExistingFiles.Name = "grpExistingFiles";
             this.grpExistingFiles.Size = new System.Drawing.Size(142, 56);
             this.grpExistingFiles.TabIndex = 20;
@@ -269,7 +271,7 @@
             // labOverwrite
             // 
             this.labOverwrite.AutoSize = true;
-            this.labOverwrite.Location = new System.Drawing.Point(62, 252);
+            this.labOverwrite.Location = new System.Drawing.Point(62, 278);
             this.labOverwrite.Name = "labOverwrite";
             this.labOverwrite.Size = new System.Drawing.Size(80, 13);
             this.labOverwrite.TabIndex = 22;
@@ -372,7 +374,7 @@
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.prgProgressBar});
             this.statusStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
-            this.statusStrip1.Location = new System.Drawing.Point(0, 827);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 848);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Size = new System.Drawing.Size(764, 22);
             this.statusStrip1.SizingGrip = false;
@@ -408,7 +410,7 @@
             this.colProcessedFiles,
             this.colSkipped,
             this.colExceptions});
-            this.dataStatus.Location = new System.Drawing.Point(195, 528);
+            this.dataStatus.Location = new System.Drawing.Point(195, 548);
             this.dataStatus.MultiSelect = false;
             this.dataStatus.Name = "dataStatus";
             this.dataStatus.ReadOnly = true;
@@ -501,7 +503,7 @@
             // txtLog
             // 
             this.txtLog.BackColor = System.Drawing.SystemColors.Window;
-            this.txtLog.Location = new System.Drawing.Point(12, 593);
+            this.txtLog.Location = new System.Drawing.Point(12, 613);
             this.txtLog.Multiline = true;
             this.txtLog.Name = "txtLog";
             this.txtLog.ReadOnly = true;
@@ -511,11 +513,23 @@
             this.txtLog.TabStop = false;
             this.txtLog.WordWrap = false;
             // 
+            // chkLocalizedString
+            // 
+            this.chkLocalizedString.AutoSize = true;
+            this.chkLocalizedString.Checked = true;
+            this.chkLocalizedString.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkLocalizedString.Location = new System.Drawing.Point(144, 229);
+            this.chkLocalizedString.Name = "chkLocalizedString";
+            this.chkLocalizedString.Size = new System.Drawing.Size(199, 17);
+            this.chkLocalizedString.TabIndex = 15;
+            this.chkLocalizedString.Text = "Dump localized strings instead of IDs";
+            this.chkLocalizedString.UseVisualStyleBackColor = true;
+            // 
             // frmCR2WtoText
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(764, 849);
+            this.ClientSize = new System.Drawing.Size(764, 870);
             this.Controls.Add(this.txtLog);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.dataStatus);
@@ -581,5 +595,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colProcessedFiles;
         private System.Windows.Forms.DataGridViewTextBoxColumn colSkipped;
         private System.Windows.Forms.DataGridViewTextBoxColumn colExceptions;
+        private System.Windows.Forms.CheckBox chkLocalizedString;
     }
 }

--- a/WolvenKit/Forms/frmCR2WtoText.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.cs
@@ -171,6 +171,7 @@ namespace WolvenKit.Forms
                     ListEmbedded = chkDumpEmbedded.Checked,
                     DumpFCD = chkDumpFCD.Checked,
                     DumpSDB = chkDumpSDB.Checked,
+                    LocalizeStrings = chkLocalizedString.Checked
                 };
 
                 using (Cancel = new CancellationTokenSource())
@@ -298,7 +299,6 @@ namespace WolvenKit.Forms
                     EnsurePathExists = false,
                     EnsureFileExists = false,
                     EnsureValidNames = true
-
                 };
 
                 if (folderDlg.ShowDialog() == CommonFileDialogResult.Ok)
@@ -634,6 +634,7 @@ namespace WolvenKit.Forms
         public bool ListEmbedded { get; set; }
         public bool DumpSDB { get; set; }
         public bool DumpFCD { get; set; }
+        public bool LocalizeStrings { get; set; }
     }
     internal class LoggerCR2W
     {
@@ -656,6 +657,8 @@ namespace WolvenKit.Forms
         internal LoggerCR2W(CR2WFile cr2wFile, LoggerOutputFile writer, LoggerCR2WOptions options)
         {
             CR2W = cr2wFile;
+            if (options.LocalizeStrings)
+                CR2W.LocalizedStringSource = MainController.Get();
             Chunks = CR2W.chunks;
             Embedded = CR2W.embedded;
             Writer = writer;

--- a/WolvenKit/Forms/frmCR2WtoText.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.cs
@@ -657,12 +657,12 @@ namespace WolvenKit.Forms
         internal LoggerCR2W(CR2WFile cr2wFile, LoggerOutputFile writer, LoggerCR2WOptions options)
         {
             CR2W = cr2wFile;
-            if (options.LocalizeStrings)
-                CR2W.LocalizedStringSource = MainController.Get();
             Chunks = CR2W.chunks;
             Embedded = CR2W.embedded;
             Writer = writer;
             Options = options;
+            if (Options.LocalizeStrings)
+                CR2W.LocalizedStringSource = MainController.Get();
         }
         public void processCR2W(int overrideLevel = 0)
         {

--- a/WolvenKit/Forms/frmCR2WtoText.cs
+++ b/WolvenKit/Forms/frmCR2WtoText.cs
@@ -721,7 +721,8 @@ namespace WolvenKit.Forms
                 {
                     try
                     {
-                        CR2WFile embedcr2w = new CR2WFile(((IByteSource)node.Variable).Bytes, MainController.Get().Logger);
+                        var ls = new LoggerService();
+                        CR2WFile embedcr2w = new CR2WFile( ((IByteSource)node.Variable).Bytes, ls );
                         var lc = new LoggerCR2W(embedcr2w, Writer, Options);
                         lc.processCR2W(level);
                     }


### PR DESCRIPTION
# Dump CR2W To Text: Enable dumping of localized strings instead of IDs.

Implemented:
- New option to enable dumping localized strings instead of just their IDs; defaults to checked.