### PR TITLE
Release 0.6.2 bugfixes

### DIFF
--- a/WolvenKit.App/ViewModels/ImportViewModel.cs
+++ b/WolvenKit.App/ViewModels/ImportViewModel.cs
@@ -176,18 +176,35 @@ namespace WolvenKit.App.ViewModels
                 var filepath = Path.Combine(importdepot.FullName, file.GetRelativePath());
                 string type = REDTypes.RawExtensionToCacheType(rawext);
 
-                if (relPath.Substring(0, 3) == "Raw") relPath = relPath.TrimStart("Raw".ToCharArray());
-                relPath = relPath.TrimStart(Path.DirectorySeparatorChar);
-                if (relPath.Substring(0, 3) == "Mod") relPath = relPath.TrimStart("Mod".ToCharArray());
-                relPath = relPath.TrimStart(Path.DirectorySeparatorChar);
-                if (relPath.Substring(0, 3) == "DLC") relPath = relPath.TrimStart("DLC".ToCharArray());
-                relPath = relPath.TrimStart(Path.DirectorySeparatorChar);
+                // make new path
+                // first, trim Raw from the path
+                if (relPath.Substring(0, 3) == "Raw" )
+                    relPath = relPath.Substring(4);
+                // then, trim Mod or dlc from the path
+                bool isDLC = false;
+                if (relPath.Substring(0, 3) == "Mod")
+                {
+                    relPath = relPath.Substring(4);
+                }
+                if (relPath.Substring(0, 3) == "DLC")
+                {
+                    isDLC = true;
+                    relPath = relPath.Substring(4);
+                }
 
-                var newpath = Path.Combine(ActiveMod.ModDirectory, relPath);
-                newpath = Path.ChangeExtension(newpath, importext);
-                var split = relPath.Split(Path.DirectorySeparatorChar).First();
-                if (split != type)
-                    newpath = Path.Combine(ActiveMod.ModDirectory, type, $"{relPath.TrimEnd(rawext.ToCharArray())}{importext}");
+                // new path with new extension
+                relPath = Path.ChangeExtension(relPath, importext);
+
+                // check if directory starts with TextureCache or CollisionCache
+                var newpath = "";
+                if (relPath.Substring(0, type.Length) == type)
+                {
+                    newpath = isDLC ? Path.Combine(ActiveMod.DlcDirectory, relPath) : Path.Combine(ActiveMod.ModDirectory, relPath);
+                }
+                else
+                {
+                    newpath = isDLC ? Path.Combine(ActiveMod.DlcDirectory, type, relPath) : Path.Combine(ActiveMod.ModDirectory, type, relPath);
+                }
 
                 var import = new Wcc_lite.import()
                 {

--- a/WolvenKit.CR2W/Types/Utils/CR2WTypeManager.cs
+++ b/WolvenKit.CR2W/Types/Utils/CR2WTypeManager.cs
@@ -82,6 +82,7 @@ namespace WolvenKit.CR2W.Types
 
             #region Flags
             Register("Flags", new CFlags(null));
+
             Register("EDrawableFlags", new CFlags(null));
             Register("ETriggerChannel", new CFlags(null));
             Register("ELightChannel", new CFlags(null));

--- a/WolvenKit.CR2W/Types/Utils/Enums.cs
+++ b/WolvenKit.CR2W/Types/Utils/Enums.cs
@@ -91,6 +91,15 @@ namespace WolvenKit.CR2W.Types
 
         #region Flags
         [Flags]
+        public enum ELightChannel
+        {
+            LC_Characters,
+            LC_Interactive,
+            LC_Custom0,
+            LC_FoliageOutline,
+            LC_VisibleThroughtWalls
+        }
+        [Flags]
         public enum EDismembermentEffectTypeFlag
         {
             DETF_Base = 1,

--- a/WolvenKit/Forms/frmMain.cs
+++ b/WolvenKit/Forms/frmMain.cs
@@ -2535,6 +2535,10 @@ Would you like to open the problem steps recorder?", "Bug reporting", MessageBox
             var pack = PackAndInstallMod();
             while (!pack.IsCompleted)
                 Application.DoEvents();
+
+            if (!pack.Result)
+                return;
+
             var getparams = new Input("Please give the commands to launch the game with!");
             if (getparams.ShowDialog() == DialogResult.OK)
             {
@@ -2548,6 +2552,8 @@ Would you like to open the problem steps recorder?", "Bug reporting", MessageBox
             while (!pack.IsCompleted)
                 Application.DoEvents();
 
+            if (!pack.Result)
+                return;
             executeGame();
         }
 
@@ -2737,14 +2743,14 @@ Would you like to open the problem steps recorder?", "Bug reporting", MessageBox
         #endregion
 
         #region Mod Pack
-        public async Task PackAndInstallMod(bool install = true)
+        public async Task<bool> PackAndInstallMod(bool install = true)
         {
             if (ActiveMod == null)
-                return;
+                return false;
             if (Process.GetProcessesByName("Witcher3").Length != 0)
             {
                 MessageBox.Show("Please close The Witcher 3 before tinkering with the files!", "", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                return;
+                return false;
             }
 
             var packsettings = new frmPackSettings();
@@ -2985,7 +2991,12 @@ Would you like to open the problem steps recorder?", "Bug reporting", MessageBox
                 //Report that we are done
                 MainController.Get().ProjectStatus = install ? "Mod Packed&Installed" : "Mod packed!"; 
                 btPack.Enabled = true;
-            }           
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>

--- a/WolvenKit/Forms/frmMain.cs
+++ b/WolvenKit/Forms/frmMain.cs
@@ -145,6 +145,9 @@ namespace WolvenKit
             hotkeys.RegisterHotkey(Keys.F1, HKHelp, "Help");
             hotkeys.RegisterHotkey(Keys.Control | Keys.C, HKCopy, "Copy");
             hotkeys.RegisterHotkey(Keys.Control | Keys.V, HKPaste, "Paste");
+
+            hotkeys.RegisterHotkey(Keys.F5 , HKRun, "Run");
+            hotkeys.RegisterHotkey(Keys.Control | Keys.F5 , HKRunAndLaunch, "Run");
             UIController.InitForm(this);
 
             MainBackgroundWorker.WorkerReportsProgress = true;
@@ -252,6 +255,23 @@ namespace WolvenKit
         private void SetStatusLabelText(string text)
         {
             statusLBL.Text = text;
+        }
+
+        private void HKRun(HotKeyEventArgs e)
+        {
+            var pack = PackAndInstallMod();
+            while (!pack.IsCompleted)
+                Application.DoEvents();
+        }
+        private void HKRunAndLaunch(HotKeyEventArgs e)
+        {
+            var pack = PackAndInstallMod();
+            while (!pack.IsCompleted)
+                Application.DoEvents();
+
+            if (!pack.Result)
+                return;
+            executeGame();
         }
 
         private void HKSave(HotKeyEventArgs e)

--- a/WolvenKit/Forms/frmModExplorer.cs
+++ b/WolvenKit/Forms/frmModExplorer.cs
@@ -641,7 +641,8 @@ namespace WolvenKit
             {
                 if (s.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Length > 2)
                 {
-                    return string.Join(Path.DirectorySeparatorChar.ToString(), s.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Skip(2).ToArray());
+                    var relpath = s.Substring(ActiveMod.FileDirectory.Length + 1);
+                    return string.Join(Path.DirectorySeparatorChar.ToString(), relpath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Skip(2).ToArray());
                 }
                 else
                     return s;

--- a/WolvenKit/Forms/frmScriptEditor.cs
+++ b/WolvenKit/Forms/frmScriptEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
+using System.Text;
 using ScintillaNET;
 using ScintillaNET_FindReplaceDialog;
 using WeifenLuo.WinFormsUI.Docking;
@@ -176,7 +177,10 @@ namespace WolvenKit.Forms
 
         public void SaveFile()
         {
-            File.WriteAllText(FilePath, "");
+            // encode in UTF-16LE
+            Encoding enc = Encoding.Unicode;
+
+            File.WriteAllText(FilePath, "", enc);
             using (var streamWriter = File.AppendText(FilePath))
             {
                 streamWriter.Write(scintillaControl.Text);


### PR DESCRIPTION
# Release 0.6.2 bugfixes

Implemented:
- added ELightChannel enum
- F5 : pack and install mod
- Ctrl+F5: pack and install mod, launch game

Fixed:
- fixed relative path copying in ModExplorer
- fixed a bug where files in frmScriptEditor would be saved in utf8 instead of utf16LE
- fixed a bug where dlc textures would get imported as bundle in the **importUtility**
- fixed launching the game when packing is cancelled

<Additional notes>
