### PR TITLE
Fixes 0.6.1 - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository is created to demonstrate how **REDengine 3** reads and writes f
 - KNG
 - SkacikPL
 - Mezziaz
-- The modding discord (https://discord.gg/qBNgDEX)
+- The modding discord (https://discord.gg/tdSUQQe)
 
 ##### *Based on the code from "Sarcen's W3Edit" by Sarcen*.
 

--- a/Update.xml
+++ b/Update.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
     <version>0.6.0.1</version>
-    <url>https://github.com/Traderain/Wolven-kit/releases/download/Stable/WolvenKit-2020-05-06.zip</url>
+    <url>https://github.com/Traderain/Wolven-kit/releases/download/0.6.1-stable/WolvenKit-2020-06-15.zip</url>
     <changelog>https://raw.githubusercontent.com/Traderain/Wolven-kit/master/ChangeLog.txt</changelog>
     <mandatory>false</mandatory>
 </item>


### PR DESCRIPTION
# Update README.md

Fixed:
- fixed invalid old discord invite link in the readme

<Additional notes>
closes #187 