### PR TITLE
- Reworked wcclite dump to xml to allow for individual file export.

### DIFF
--- a/WolvenKit.App/ViewModels/MainViewModel.cs
+++ b/WolvenKit.App/ViewModels/MainViewModel.cs
@@ -209,15 +209,27 @@ namespace WolvenKit.App.ViewModels
         #endregion
 
         #region WCC TASKS
-        public async Task DumpFile(string folder, string outfolder)
+        public async Task DumpFile(string folder, string outfolder, string file="")
         {
+            WCC_Command cmd = null;
             try
             {
-                var cmd = new Wcc_lite.dumpfile()
+                if (file=="")
                 {
-                    Dir = folder,
-                    Out = outfolder
-                };
+                    cmd = new Wcc_lite.dumpfile()
+                    {
+                        Dir = folder,
+                        Out = outfolder
+                    };
+                }
+                else
+                {
+                    cmd = new Wcc_lite.dumpfile()
+                    {
+                        File = file,
+                        Out = outfolder
+                    };
+                }
                 await Task.Run(() => MainController.Get().WccHelper.RunCommand(cmd));
             }
             catch (Exception ex)

--- a/WolvenKit.Common/Model/Wcc/wcc_command.cs
+++ b/WolvenKit.Common/Model/Wcc/wcc_command.cs
@@ -103,6 +103,8 @@ namespace WolvenKit.Common.Wcc
                             val = val.Replace(@"\", @"\\"); //FIXME? it's stupid but seems to work
                         }
                         val = $"=\"{val}\"";
+                        //The end of the atomic dumpfile horror :
+                        if (val == "=\"\\\\\\\\?\\\\\\\\\"") val = "=" + @"\\?\";
                     }
                     // other strings
                     else

--- a/WolvenKit.Common/Model/Wcc/wcc_commands.cs
+++ b/WolvenKit.Common/Model/Wcc/wcc_commands.cs
@@ -252,13 +252,6 @@ namespace WolvenKit.Common.Wcc
         [REDName("dir")]
         public string Dir { get; set; }
 
-        [CategoryAttribute("Is Required"),
-        DescriptionAttribute("absolute path to the output file")]
-        //[Editor(typeof(PropertyGridFolderPicker), typeof(PropertyGridFolderPicker))]
-        [REDTags("Path", "Out")]
-        [REDName("out")]
-        public string Out { get; set; }
-
         /// <summary>
         /// Optional
         /// </summary>
@@ -268,6 +261,13 @@ namespace WolvenKit.Common.Wcc
         [REDTags("Path", "In")]
         [REDName("file")]
         public string File { get; set; }
+
+        [CategoryAttribute("Is Required"),
+        DescriptionAttribute("absolute path to the output file")]
+        //[Editor(typeof(PropertyGridFolderPicker), typeof(PropertyGridFolderPicker))]
+        [REDTags("Path", "Out")]
+        [REDName("out")]
+        public string Out { get; set; }
 
         [CategoryAttribute("Optional"),
         DescriptionAttribute("exclude given file extensions")]

--- a/WolvenKit/Forms/frmModExplorer.cs
+++ b/WolvenKit/Forms/frmModExplorer.cs
@@ -67,7 +67,7 @@ namespace WolvenKit
                 }
                 return extension;
             };
-
+            treeListView.RevealAfterExpand=false;
 
             // Update the TreeView
             vm.RepopulateTreeView();


### PR DESCRIPTION
  Before this commit exporting a single file triggered a recursive
  export for the entire parent directory.
  Note : this is a terrible hack...

- Made the modexplorer treelistview to not reveal after expand,
  in case of long lists this became quickly annoying.