### PR TITLE
main controller fixes

### DIFF
--- a/WolvenKit.App/Controllers/MainController.cs
+++ b/WolvenKit.App/Controllers/MainController.cs
@@ -94,27 +94,36 @@ namespace WolvenKit.App
         #region Archive Managers
         private SoundManager soundManager;
         private SoundManager modsoundmanager;
+
         private BundleManager bundleManager;
         private BundleManager modbundleManager;
+        
         private TextureManager textureManager;
-        private CollisionManager collisionManager;
         private TextureManager modTextureManager;
+
+        private CollisionManager collisionManager;
+        private CollisionManager modCollisionManager;
+
         private W3StringManager w3StringManager;
         private SpeechManager speechManager;
 
         //Public getters
         public W3StringManager W3StringManager => w3StringManager;
 
-      
 
-        public BundleManager BundleManager => bundleManager;
-        public BundleManager ModBundleManager => modbundleManager;
+        private BundleManager BundleManager => bundleManager;
+        private BundleManager ModBundleManager => modbundleManager;
+
         public SoundManager SoundManager => soundManager;
-        public SoundManager ModSoundManager => modsoundmanager;
+        private SoundManager ModSoundManager => modsoundmanager;
+
         public TextureManager TextureManager => textureManager;
-        public TextureManager ModTextureManager => modTextureManager;
-        public CollisionManager CollisionManager => collisionManager;
-        public SpeechManager SpeechManager => speechManager;
+        private TextureManager ModTextureManager => modTextureManager;
+
+        private CollisionManager CollisionManager => collisionManager;
+        private CollisionManager ModCollisionManager => modCollisionManager;
+
+        private SpeechManager SpeechManager => speechManager;
 
         //public Dictionary<string, MemoryMappedFile> mmfs = new Dictionary<string, MemoryMappedFile>();
 
@@ -140,6 +149,11 @@ namespace WolvenKit.App
                     MainController.Get().ModTextureManager.LoadModsBundles(exeDir);
                     managers.Add(MainController.Get().ModTextureManager);
                 }
+                if (MainController.Get().ModCollisionManager != null)
+                {
+                    MainController.Get().ModCollisionManager.LoadModsBundles(exeDir);
+                    managers.Add(MainController.Get().ModCollisionManager);
+                }
             }
             else
             {
@@ -156,7 +170,7 @@ namespace WolvenKit.App
         #endregion
 
         #region Logging
-        public LoggerService Logger { get; set; }
+        public LoggerService Logger { get; private set; }
 
         private KeyValuePair<string, Logtype> _logMessage = new KeyValuePair<string, Logtype>("", Logtype.Normal);
         public KeyValuePair<string, Logtype> LogMessage
@@ -338,6 +352,14 @@ namespace WolvenKit.App
                     }
                 }
                 #endregion
+                loadStatus = "Loading mod texure manager!";
+                #region Load mod texture manager
+                if (modTextureManager == null)
+                {
+                    modTextureManager = new TextureManager();
+                    modTextureManager.LoadModsBundles(Path.GetDirectoryName(Configuration.ExecutablePath));
+                }
+                #endregion
 
                 loadStatus = "Loading collision manager!";
                 #region Load collision manager
@@ -377,6 +399,14 @@ namespace WolvenKit.App
                     }
                 }
                 #endregion
+                loadStatus = "Loading mod collision manager!";
+                #region Load mod collision manager
+                if (modCollisionManager == null)
+                {
+                    modCollisionManager = new CollisionManager();
+                    modCollisionManager.LoadModsBundles(Path.GetDirectoryName(Configuration.ExecutablePath));
+                }
+                #endregion
 
                 loadStatus = "Loading speech manager!";
                 #region Load speech manager
@@ -384,15 +414,6 @@ namespace WolvenKit.App
                 {
                     speechManager = new SpeechManager();
                     speechManager.LoadAll(Path.GetDirectoryName(Configuration.ExecutablePath));
-                }
-                #endregion
-
-                loadStatus = "Loading mod texure manager!";
-                #region Load mod texture manager
-                if (modTextureManager == null)
-                {
-                    modTextureManager = new TextureManager();
-                    modTextureManager.LoadModsBundles(Path.GetDirectoryName(Configuration.ExecutablePath));
                 }
                 #endregion
 
@@ -434,7 +455,6 @@ namespace WolvenKit.App
                     }
                 }
                 #endregion
-
                 loadStatus = "Loading mod sound manager!";
                 #region Load mod sound manager
                 if (modsoundmanager == null)

--- a/WolvenKit.Bundles/BundleManager.cs
+++ b/WolvenKit.Bundles/BundleManager.cs
@@ -102,7 +102,7 @@ namespace WolvenKit.Bundles
             var di = new DirectoryInfo(exedir);
             if (!di.Exists)
                 return;
-
+            var dlc = Path.Combine(di.Parent.Parent.FullName, "DLC");
             var content = Path.Combine(di.Parent.Parent.FullName, "content");
 
             var contentdirs = new List<string>(Directory.GetDirectories(content, "content*"));
@@ -114,12 +114,12 @@ namespace WolvenKit.Bundles
 
             var patchdirs = new List<string>(Directory.GetDirectories(content, "patch*"));
             patchdirs.Sort(new AlphanumComparator<string>());
-            foreach (var file in patchdirs.SelectMany(dir => Directory.GetFiles(dir, "*.bundle", SearchOption.AllDirectories)))
+            foreach (var file in patchdirs.SelectMany(dir =>
+                Directory.GetFiles(dir, "*.bundle", SearchOption.AllDirectories)))
             {
                 LoadBundle(file, true);
             }
 
-            var dlc = Path.Combine(di.Parent.Parent.FullName, "DLC");
             if (Directory.Exists(dlc))
             {
                 var dlcdirs = new List<string>(Directory.GetDirectories(dlc));
@@ -145,7 +145,12 @@ namespace WolvenKit.Bundles
         /// <param name="exedir"></param>
         public void LoadModsBundles(string exedir)
         {
-            var mods = Path.Combine(exedir, @"..\..\Mods\");
+            var di = new DirectoryInfo(exedir);
+            if (!di.Exists)
+                return;
+            var mods = Path.Combine(di.Parent.Parent.FullName, "Mods");
+            var dlc = Path.Combine(di.Parent.Parent.FullName, "DLC");
+
             if (!Directory.Exists(mods))
                 Directory.CreateDirectory(mods);
             var modsdirs = new List<string>(Directory.GetDirectories(mods));
@@ -155,8 +160,7 @@ namespace WolvenKit.Bundles
             {
                 LoadModBundle(file);
             }
-
-            var dlc = Path.Combine(exedir, @"..\..\DLC\");
+            
             if (Directory.Exists(dlc))
             {
                 var dlcdirs = new List<string>(Directory.GetDirectories(dlc));

--- a/WolvenKit.W3Speech/SpeechManager.cs
+++ b/WolvenKit.W3Speech/SpeechManager.cs
@@ -31,13 +31,16 @@ namespace WolvenKit.W3Speech
         public List<string> Extensions { get; set; }
         public AutoCompleteStringCollection AutocompleteSource { get; set; }
 
+        private readonly string[] vanillaDLClist = new string[] { "DLC1", "DLC2", "DLC3", "DLC4", "DLC5", "DLC6", "DLC7", "DLC8", "DLC9", "DLC10", "DLC11", "DLC12", "DLC13", "DLC14", "DLC15", "DLC16", "bob", "ep1" };
+
+
         /// <summary>
         ///     Load a single mod bundle
         /// </summary>
         /// <param name="filename">
         ///     file to process
         /// </param>
-        public void LoadModBundle(string filename)
+        private void LoadModBundle(string filename)
         {
             if (Speeches.ContainsKey(filename))
                 return;
@@ -59,7 +62,7 @@ namespace WolvenKit.W3Speech
         ///     Load a single bundle
         /// </summary>
         /// <param name="filename"></param>
-        public void LoadBundle(string filename)
+        private void LoadBundle(string filename)
         {
             try
             {
@@ -96,7 +99,11 @@ namespace WolvenKit.W3Speech
         /// <param name="exedir">Path to executable directory</param>
         public void LoadAll(string exedir)
         {
-            var content = Path.Combine(exedir, @"..\..\content\");
+            var di = new DirectoryInfo(exedir);
+            if (!di.Exists)
+                return;
+
+            var content = Path.Combine(di.Parent.Parent.FullName, "content");
 
             var contentdirs = new List<string>(Directory.GetDirectories(content, "content*"));
             contentdirs.Sort(new AlphanumComparator<string>());
@@ -112,12 +119,16 @@ namespace WolvenKit.W3Speech
                 LoadBundle(file);
             }
 
-            var dlc = Path.Combine(exedir, @"..\..\DLC\");
+            var dlc = Path.Combine(di.Parent.Parent.FullName, "DLC");
             if (Directory.Exists(dlc))
             {
                 var dlcdirs = new List<string>(Directory.GetDirectories(dlc));
                 dlcdirs.Sort(new AlphanumComparator<string>());
-                foreach (var file in dlcdirs.Where(dir => new Regex("(DLC..)|(DLC.)|(BOB)|(ep.)|(bob)|(EP.)").IsMatch(Path.GetFileName(dir ?? ""))).SelectMany(dir => Directory.GetFiles(dir ?? "", "*.w3speech", SearchOption.AllDirectories).OrderBy(k => k)))
+
+                foreach (var file in dlcdirs
+                    .Where(_ => vanillaDLClist.Contains(new DirectoryInfo(_).Name))
+                    .SelectMany(dir => Directory.GetFiles(dir ?? "", "*.w3speech", SearchOption.AllDirectories)
+                        .OrderBy(k => k)))
                 {
                     LoadBundle(file);
                 }
@@ -132,7 +143,12 @@ namespace WolvenKit.W3Speech
         /// <param name="exedir"></param>
         public void LoadModsBundles(string exedir)
         {
-            var mods = Path.Combine(exedir, @"..\..\Mods\");
+            var di = new DirectoryInfo(exedir);
+            if (!di.Exists)
+                return;
+            var mods = Path.Combine(di.Parent.Parent.FullName, "Mods");
+            var dlc = Path.Combine(di.Parent.Parent.FullName, "DLC");
+
             if (!Directory.Exists(mods))
                 Directory.CreateDirectory(mods);
             var modsdirs = new List<string>(Directory.GetDirectories(mods));
@@ -143,12 +159,15 @@ namespace WolvenKit.W3Speech
                 LoadModBundle(file);
             }
 
-            var dlc = Path.Combine(exedir, @"..\..\DLC\");
             if (Directory.Exists(dlc))
             {
                 var dlcdirs = new List<string>(Directory.GetDirectories(dlc));
                 dlcdirs.Sort(new AlphanumComparator<string>());
-                foreach (var file in dlcdirs.Where(dir => !new Regex("(DLC..)|(DLC.)|(BOB)|(bob)|(EP.)|(ep.)").IsMatch(Path.GetFileName(dir ?? ""))).SelectMany(dir => Directory.GetFiles(dir ?? "", "*.w3speech", SearchOption.AllDirectories).OrderBy(k => k)))
+
+                var tmp = dlcdirs.Where(_ => !vanillaDLClist.Contains(new DirectoryInfo(_).Name)).ToList();
+                foreach (var file in tmp
+                    .SelectMany(dir => Directory.GetFiles(dir ?? "", "*.w3speech", SearchOption.AllDirectories)
+                        .OrderBy(k => k)))
                 {
                     LoadModBundle(file);
                 }
@@ -156,7 +175,7 @@ namespace WolvenKit.W3Speech
             RebuildRootNode();
         }
 
-        public static string GetModFolder(string path)
+        private static string GetModFolder(string path)
         {
             if (path.Split('\\').Length > 3 && path.Split('\\').Contains("content"))
             {
@@ -168,7 +187,7 @@ namespace WolvenKit.W3Speech
         /// <summary>
         ///     Rebuilds the bundle tree structure also rebuilds NOTE: Filelist,autocomplete,extensions
         /// </summary>
-        public void RebuildRootNode()
+        private void RebuildRootNode()
         {
             RootNode = new WitcherTreeNode(EBundleType.Speech);
             RootNode.Name = EBundleType.Speech.ToString();
@@ -205,7 +224,7 @@ namespace WolvenKit.W3Speech
         /// <summary>
         /// Calls GetFiles on the rootnode
         /// </summary>
-        public void RebuildFileList()
+        private void RebuildFileList()
         {
             FileList = GetFiles(RootNode);
         }
@@ -213,7 +232,7 @@ namespace WolvenKit.W3Speech
         /// <summary>
         /// Gets the avaliable extensions in the files
         /// </summary>
-        public void RebuildExtensions()
+        private void RebuildExtensions()
         {
             foreach (var file in FileList.Where(file => !Extensions.Contains(file.Name.Split('.').Last())))
             {
@@ -225,7 +244,7 @@ namespace WolvenKit.W3Speech
         /// <summary>
         /// Gets the distinct filenames from the loaded bundles so they can be used for autocomplete
         /// </summary>
-        public void RebuildAutoCompleteSource()
+        private void RebuildAutoCompleteSource()
         {
             AutocompleteSource.AddRange(FileList.Select(x => GetFileName(x.Name)).Distinct().ToArray());
         }
@@ -235,7 +254,7 @@ namespace WolvenKit.W3Speech
         /// </summary>
         /// <param name="mainnode">The rootnode to get the files from</param>
         /// <returns></returns>
-        public List<IWitcherFile> GetFiles(WitcherTreeNode mainnode)
+        private List<IWitcherFile> GetFiles(WitcherTreeNode mainnode)
         {
             var bundfiles = new List<IWitcherFile>();
             if (mainnode?.Files != null)
@@ -254,7 +273,7 @@ namespace WolvenKit.W3Speech
         /// </summary>
         /// <param name="s">Path/Name of the file</param>
         /// <returns></returns>
-        public string GetFileName(string s)
+        private string GetFileName(string s)
         {
             return s.Contains('\\') ? s.Split('\\').Last() : s;
         }


### PR DESCRIPTION
# main controller fixes

Fixed:
- fixed a bug where the mod managers would misidentify vanilla dlc
- fixed a bug where the collision manager for mods was not defined

<Additional notes>
