### PR TITLE
mod workflow fixes

### DIFF
--- a/WolvenKit.App/ViewModels/MainViewModel.cs
+++ b/WolvenKit.App/ViewModels/MainViewModel.cs
@@ -1036,7 +1036,11 @@ namespace WolvenKit.App.ViewModels
                     for (int i = 0; i < files.Length; i++)
                     {
                         var file = files[i];
-                        var relpath = $"dlc\\{file.FullName.Substring(uncookeddlcdir.FullName.Length + 1)}";
+                        var relpath = $"{file.FullName.Substring(uncookeddlcdir.FullName.Length + 1)}";
+                        if (!relpath.StartsWith("dlc\\"))
+                        {
+                            relpath = $"dlc\\{relpath}";
+                        }
 
                         relpath = relpath.Replace("\\", "\\\\");
                         sr.WriteLine("\t\t{");
@@ -1066,9 +1070,13 @@ namespace WolvenKit.App.ViewModels
             if (string.IsNullOrEmpty(ActiveMod.GetDlcUncookedRelativePath()))
                 return;
 
-            string r4link = $"{MainController.Get().Configuration.DepotPath}\\dlc\\{ActiveMod.GetDlcName()}";
-            //string projlink = $"{ActiveMod.DlcUncookedDirectory}\\dlc\\{ActiveMod.GetDlcName()}";
+            // hack to determine if older project
+            string r4link = Path.Combine(MainController.Get().Configuration.DepotPath, "dlc", ActiveMod.GetDlcName());
             string projlink = Path.Combine(ActiveMod.DlcUncookedDirectory, ActiveMod.GetDlcUncookedRelativePath());
+            if (new DirectoryInfo(ActiveMod.DlcUncookedDirectory).GetDirectories().Any(_ => _.Name == "dlc"))
+            {
+                projlink = Path.Combine(ActiveMod.DlcUncookedDirectory, "dlc", ActiveMod.GetDlcUncookedRelativePath());
+            }
 
             if (Directory.Exists(r4link))
             {

--- a/WolvenKit.App/ViewModels/MainViewModel.cs
+++ b/WolvenKit.App/ViewModels/MainViewModel.cs
@@ -638,7 +638,7 @@ namespace WolvenKit.App.ViewModels
                     //Delete the old install log. We will make a new one so this is not needed anymore.
                     File.Delete(ActiveMod.ProjectDirectory + "\\install_log.xml");
                 }
-                XDocument installlog = new XDocument(new XElement("InstalLog", new XAttribute("Project", ActiveMod.Name), new XAttribute("Build_date", DateTime.Now.ToString())));
+                var installlog = new XDocument(new XElement("InstalLog", new XAttribute("Project", ActiveMod.Name), new XAttribute("Build_date", DateTime.Now.ToString())));
                 var fileroot = new XElement("Files");
                 //Copy and log the files.
                 if (!Directory.Exists(Path.Combine(ActiveMod.ProjectDirectory, "packed")))
@@ -794,7 +794,7 @@ namespace WolvenKit.App.ViewModels
 
                         if (dlc)
                         {
-                            cook.trimdir = ActiveMod.GetDLCRelativePath();
+                            cook.trimdir = $"dlc\\{ActiveMod.GetDlcName()}";
                             var seeddir = Path.Combine(ActiveMod.ProjectDirectory, @"cooked", $"seed_dlc{ActiveMod.Name}.files");
                             cook.seed = seeddir;
                         }
@@ -1035,8 +1035,9 @@ namespace WolvenKit.App.ViewModels
                     FileInfo[] files = uncookeddlcdir.GetFiles("*", SearchOption.AllDirectories);
                     for (int i = 0; i < files.Length; i++)
                     {
-                        FileInfo file = files[i];
-                        var relpath = file.FullName.Substring(uncookeddlcdir.FullName.Length + 1);
+                        var file = files[i];
+                        var relpath = $"dlc\\{file.FullName.Substring(uncookeddlcdir.FullName.Length + 1)}";
+
                         relpath = relpath.Replace("\\", "\\\\");
                         sr.WriteLine("\t\t{");
                         sr.WriteLine($"\t\t\t\"path\": \"{relpath}\",");
@@ -1060,23 +1061,23 @@ namespace WolvenKit.App.ViewModels
         /// </summary>
         public void CreateVirtualLinks()
         {
-            if (string.IsNullOrEmpty(ActiveMod.GetDLCName()))
+            if (string.IsNullOrEmpty(ActiveMod.GetDlcName()))
+                return;
+            if (string.IsNullOrEmpty(ActiveMod.GetDlcUncookedRelativePath()))
                 return;
 
-            string r4link = $"{MainController.Get().Configuration.DepotPath}\\dlc\\{ActiveMod.GetDLCName()}";
-            string projlink = $"{ActiveMod.DlcUncookedDirectory}\\dlc\\{ActiveMod.GetDLCName()}";
-
+            string r4link = $"{MainController.Get().Configuration.DepotPath}\\dlc\\{ActiveMod.GetDlcName()}";
+            //string projlink = $"{ActiveMod.DlcUncookedDirectory}\\dlc\\{ActiveMod.GetDlcName()}";
+            string projlink = Path.Combine(ActiveMod.DlcUncookedDirectory, ActiveMod.GetDlcUncookedRelativePath());
 
             if (Directory.Exists(r4link))
             {
-                var dbg = new DirectoryInfo(r4link);
-
                 Directory.Delete(r4link);
             }
             if (!Directory.Exists(r4link))
             {
                 string args = $"/c mklink /J \"{r4link}\" \"{projlink}\"";
-                ProcessStartInfo startInfo = new ProcessStartInfo("cmd.exe", args)
+                var startInfo = new ProcessStartInfo("cmd.exe", args)
                 {
                     WindowStyle = ProcessWindowStyle.Minimized
                 };

--- a/WolvenKit.Common/Model/W3Mod.cs
+++ b/WolvenKit.Common/Model/W3Mod.cs
@@ -231,11 +231,11 @@ namespace WolvenKit.Common
         {
             get
             {
-                if (string.IsNullOrEmpty(GetDLCName()))
+                if (string.IsNullOrEmpty(GetDlcName()))
                 {
                     return null;
                 }
-                var dir = Path.Combine(ProjectDirectory, "cooked", "DLC", GetDLCName(), "content");
+                var dir = Path.Combine(ProjectDirectory, "cooked", "DLC", GetDlcName(), "content");
                 if (!Directory.Exists(dir))
                     Directory.CreateDirectory(dir);
                 return dir;
@@ -248,11 +248,11 @@ namespace WolvenKit.Common
         {
             get
             {
-                if (string.IsNullOrEmpty(GetDLCName()))
+                if (string.IsNullOrEmpty(GetDlcName()))
                 {
                     return null;
                 }
-                var dir = Path.Combine(ProjectDirectory, "packed", "DLC", GetDLCName(), "content");
+                var dir = Path.Combine(ProjectDirectory, "packed", "DLC", GetDlcName(), "content");
                 if (!Directory.Exists(dir))
                     Directory.CreateDirectory(dir);
                 return dir;
@@ -406,68 +406,49 @@ namespace WolvenKit.Common
 
 
         /// <summary>
-        /// Returns the first folder name in the ActiveMod/dlc directory
+        /// Returns the first relative folder path in the ActiveMod/dlc directory
         /// Does not support multiple DLC
         /// </summary>
         /// <returns></returns>
-        public string GetDLCName()
+        public string GetDlcName()
         {
-            string dlcname = "";
-            dlcname = $"dlc{Name}";
-            //try
-            //{
-            //    if (Directory.Exists(Path.Combine(DlcCookedDirectory, "dlc")))
-            //    {
-            //        if (Directory.GetDirectories(Path.Combine(DlcCookedDirectory, "dlc")).Any())
-            //            return (new DirectoryInfo(Directory.GetDirectories(Path.Combine(DlcCookedDirectory, "dlc")).First())).Name;
-
-            //    }
-            //    else if (Directory.Exists(Path.Combine(DlcUncookedDirectory, "dlc")))
-            //    {
-            //        if (Directory.GetDirectories(Path.Combine(DlcUncookedDirectory, "dlc")).Any())
-            //            return (new DirectoryInfo(Directory.GetDirectories(Path.Combine(DlcUncookedDirectory, "dlc")).First())).Name;
-            //    }
-            //}
-            //catch (Exception)
-            //{
-            //}
-            return dlcname;
+            if (!string.IsNullOrEmpty(GetDlcCookedRelativePath()))
+                return GetDlcCookedRelativePath();
+            if (!string.IsNullOrEmpty(GetDlcUncookedRelativePath()))
+                return GetDlcUncookedRelativePath();
+            return "";
         }
 
         /// <summary>
-        /// Returns the first reltive folder path in the ActiveMod/dlc directory
-        /// Does not support multiple DLC
+        /// Returns the first folder name in the DlcCookedDirectory.
+        /// Does not support multiple dlc
         /// </summary>
         /// <returns></returns>
-        public string GetDLCRelativePath()
+        public string GetDlcCookedRelativePath()
         {
             string relpath = "";
-            try
+            if (Directory.Exists(DlcCookedDirectory) && Directory.GetDirectories(DlcCookedDirectory).Any())
             {
-                if (Directory.Exists(Path.Combine(DlcCookedDirectory, "dlc")))
-                {
-                    if (Directory.GetDirectories(Path.Combine(DlcCookedDirectory, "dlc")).Any())
-                    {
-                        relpath = (new DirectoryInfo(Directory.GetDirectories(Path.Combine(DlcCookedDirectory, "dlc")).First())).FullName;
-                        return relpath.Substring(DlcCookedDirectory.Length + 1);
-                    }
-
-                }
-                else if (Directory.Exists(Path.Combine(DlcUncookedDirectory, "dlc")))
-                {
-                    if (Directory.GetDirectories(Path.Combine(DlcUncookedDirectory, "dlc")).Any())
-                    {
-                        relpath = (new DirectoryInfo(Directory.GetDirectories(Path.Combine(DlcUncookedDirectory, "dlc")).First())).FullName;
-                        return relpath.Substring(DlcUncookedDirectory.Length + 1);
-                    }
-
-                }
-            }
-            catch (Exception)
-            {
+                relpath = (new DirectoryInfo(Directory.GetDirectories(DlcCookedDirectory).First())).FullName;
+                return relpath.Substring(DlcCookedDirectory.Length + 1);
             }
             return relpath;
         }
 
+        /// <summary>
+        /// Returns the first folder name in the DlcUncookedDirectory.
+        /// Does not support multiple dlc
+        /// </summary>
+        /// <returns></returns>
+        public string GetDlcUncookedRelativePath()
+        {
+            string relpath = "";
+            if (Directory.Exists(DlcUncookedDirectory) && Directory.GetDirectories(DlcUncookedDirectory).Any())
+            {
+                relpath = (new DirectoryInfo(Directory.GetDirectories(DlcUncookedDirectory).First())).FullName;
+                return relpath.Substring(DlcUncookedDirectory.Length + 1);
+            }
+            return relpath;
+        }
     }
 }

--- a/WolvenKit.Common/Model/W3Mod.cs
+++ b/WolvenKit.Common/Model/W3Mod.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Security.AccessControl;
 using System.Xml.Serialization;
 using WolvenKit.Common.Model;
 
@@ -427,9 +428,25 @@ namespace WolvenKit.Common
         public string GetDlcCookedRelativePath()
         {
             string relpath = "";
-            if (Directory.Exists(DlcCookedDirectory) && Directory.GetDirectories(DlcCookedDirectory).Any())
+            var di = new DirectoryInfo(DlcCookedDirectory);
+            if (di.Exists && di.GetDirectories().Any())
             {
-                relpath = (new DirectoryInfo(Directory.GetDirectories(DlcCookedDirectory).First())).FullName;
+                // support older projects
+                if (di.GetDirectories().Any(_ => _.Name == "dlc"))
+                {
+                    var subdi = di.GetDirectories().First(_ => _.Name == "dlc");
+                    if (subdi.Exists && subdi.GetDirectories().Any())
+                    {
+                        relpath = subdi.GetDirectories().First().FullName;
+                        return relpath.Substring(DlcCookedDirectory.Length + 5);
+                    }
+                    else
+                    {
+                        return "";
+                    }
+                }
+                else
+                    relpath = di.GetDirectories().First().FullName;
                 return relpath.Substring(DlcCookedDirectory.Length + 1);
             }
             return relpath;
@@ -443,9 +460,25 @@ namespace WolvenKit.Common
         public string GetDlcUncookedRelativePath()
         {
             string relpath = "";
-            if (Directory.Exists(DlcUncookedDirectory) && Directory.GetDirectories(DlcUncookedDirectory).Any())
+            var di = new DirectoryInfo(DlcUncookedDirectory);
+            if (di.Exists && di.GetDirectories().Any())
             {
-                relpath = (new DirectoryInfo(Directory.GetDirectories(DlcUncookedDirectory).First())).FullName;
+                // support older projects
+                if (di.GetDirectories().Any(_ => _.Name == "dlc"))
+                {
+                    var subdi = di.GetDirectories().First(_ => _.Name == "dlc");
+                    if (subdi.Exists && subdi.GetDirectories().Any())
+                    {
+                        relpath = subdi.GetDirectories().First().FullName;
+                        return relpath.Substring(DlcUncookedDirectory.Length + 5);
+                    }
+                    else
+                    {
+                        return "";
+                    }
+                }
+                else
+                    relpath = di.GetDirectories().First().FullName;
                 return relpath.Substring(DlcUncookedDirectory.Length + 1);
             }
             return relpath;

--- a/WolvenKit/Forms/MVVM/frmModExplorer.Designer.cs
+++ b/WolvenKit/Forms/MVVM/frmModExplorer.Designer.cs
@@ -264,6 +264,7 @@ namespace WolvenKit
             this.markAsModDlcFileToolStripMenuItem.Name = "markAsModDlcFileToolStripMenuItem";
             this.markAsModDlcFileToolStripMenuItem.Size = new System.Drawing.Size(248, 26);
             this.markAsModDlcFileToolStripMenuItem.Text = "Mark as [Mod/Dlc] file";
+            this.markAsModDlcFileToolStripMenuItem.Visible = false;
             this.markAsModDlcFileToolStripMenuItem.Click += new System.EventHandler(this.markAsModDlcFileToolStripMenuItem_Click);
             // 
             // toolStripSeparator2
@@ -318,7 +319,7 @@ namespace WolvenKit
             this.toolStripLabel1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.toolStripLabel1.Name = "toolStripLabel1";
             this.toolStripLabel1.Padding = new System.Windows.Forms.Padding(2);
-            this.toolStripLabel1.Size = new System.Drawing.Size(24, 28);
+            this.toolStripLabel1.Size = new System.Drawing.Size(24, 27);
             // 
             // searchBox
             // 
@@ -389,7 +390,7 @@ namespace WolvenKit
             this.treeListView.Margin = new System.Windows.Forms.Padding(2);
             this.treeListView.Name = "treeListView";
             this.treeListView.ShowGroups = false;
-            this.treeListView.Size = new System.Drawing.Size(373, 527);
+            this.treeListView.Size = new System.Drawing.Size(373, 529);
             this.treeListView.TabIndex = 2;
             this.treeListView.UseCompatibleStateImageBehavior = false;
             this.treeListView.UseFiltering = true;

--- a/WolvenKit/Forms/MVVM/frmModExplorer.cs
+++ b/WolvenKit/Forms/MVVM/frmModExplorer.cs
@@ -400,7 +400,7 @@ namespace WolvenKit
                 pasteToolStripMenuItem.Enabled = File.Exists(Clipboard.GetText());
 
                 cookToolStripMenuItem.Enabled = (!Enum.GetNames(typeof(EImportable)).Contains(ext) && !isbundle && !israw);
-                markAsModDlcFileToolStripMenuItem.Enabled = isbundle && !isToplevelDir;
+                //markAsModDlcFileToolStripMenuItem.Enabled = isbundle && !isToplevelDir;
 
                 showFileInExplorerToolStripMenuItem.Text = selectedobject.IsDirectory() ? "Open Folder in Explorer" : "Open File in Explorer";
                 FileActionsToolStripMenuItem.Enabled = !israw;
@@ -552,6 +552,7 @@ namespace WolvenKit
             }
         }
 
+        // deprecated
         private void markAsModDlcFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (!(treeListView.SelectedObject is FileSystemInfo selectedobject)) return;

--- a/WolvenKit/Forms/UserControl/frmPackSettings.Designer.cs
+++ b/WolvenKit/Forms/UserControl/frmPackSettings.Designer.cs
@@ -211,7 +211,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(13, 13);
+            this.label1.Location = new System.Drawing.Point(13, 10);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(72, 13);
             this.label1.TabIndex = 18;

--- a/WolvenKit/Forms/UserControl/frmPackSettings.cs
+++ b/WolvenKit/Forms/UserControl/frmPackSettings.cs
@@ -29,8 +29,18 @@ namespace WolvenKit
                 modBDL.Checked = true;
                 modMD.Checked = true;
             }
+            if (Directory.GetFiles(activemod.ModUncookedDirectory, "*.*", SearchOption.AllDirectories).Any())
+            {
+                modBDL.Checked = true;
+                modMD.Checked = true;
+            }
 
             if (Directory.GetFiles(activemod.DlcCookedDirectory, "*.*", SearchOption.AllDirectories).Any())
+            {
+                dlcBDL.Checked = true;
+                dlcMD.Checked = true;
+            }
+            if (Directory.GetFiles(activemod.DlcUncookedDirectory, "*.*", SearchOption.AllDirectories).Any())
             {
                 dlcBDL.Checked = true;
                 dlcMD.Checked = true;

--- a/WolvenKit/Properties/Resources.Designer.cs
+++ b/WolvenKit/Properties/Resources.Designer.cs
@@ -415,7 +415,7 @@ namespace WolvenKit.Properties {
         /// </summary>
         internal static System.Drawing.Bitmap git {
             get {
-                object obj = ResourceManager.GetObject("git", resourceCulture);
+                object obj = ResourceManager.GetObject($"git", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }


### PR DESCRIPTION
# mod workflow fixes

Implemented:
- trim 2 first folders when adding a file from a dlc *as* a dlc-file
- added support for older mod projects with a different dlc structure

Fixed:
- fixed a bug where virtual links were not linked correctly
- fixed a bug where the pack settings were not displayed correctly


<Additional notes>
#246 