### PR TITLE
fix for RHCS to LHCS

### DIFF
--- a/WolvenKit.Irrlicht/source/COBJMeshWriter.cpp
+++ b/WolvenKit.Irrlicht/source/COBJMeshWriter.cpp
@@ -136,7 +136,8 @@ bool COBJMeshWriter::writeMesh(io::IWriteFile* file, scene::IMesh* mesh, s32 fla
 
 			const u32 indexCount = buffer->getIndexCount();
 			const scene::IIndexBuffer& indices = buffer->getIndexBuffer();
-			if (indexCount == vertexCount * 3)
+			
+			if(buffer->getPrimitiveType() == EPT_TRIANGLES)
 			{
 				for (j = 0; j < indexCount; j += 3)
 				{
@@ -170,7 +171,7 @@ bool COBJMeshWriter::writeMesh(io::IWriteFile* file, scene::IMesh* mesh, s32 fla
 					file->write("\n", 1);
 				}
 			}
-			else // triangle strip!
+			else if (buffer->getPrimitiveType() == EPT_TRIANGLE_STRIP)
 			{
                 for (j = 0; j < indexCount - 2; j += 2)
                 {
@@ -315,7 +316,7 @@ bool COBJMeshWriter::writeMesh(io::IWriteFile* file, scene::IMesh* mesh, s32 fla
             }
             if (mat[i]->getTexture(1))
             {
-                mtlFile->write("map_Bump ", 9);
+                mtlFile->write("bump ", 5);
                 core::stringc tname = (core::stringc)(FileSystem->getFileBasename(mat[i]->getTexture(1)->getName()));
                 if (!TexExtension.empty())
                 {

--- a/WolvenKit.Irrlicht/source/CSceneManagerWolvenKit.cpp
+++ b/WolvenKit.Irrlicht/source/CSceneManagerWolvenKit.cpp
@@ -85,9 +85,6 @@ CSceneManagerWolvenKit::CSceneManagerWolvenKit(video::IVideoDriver* driver, io::
 
 
     Parameters = DBG_NEW io::CAttributes();
-
-	//TODO: fill buffer with pvs data
-	//janua_handler_load_database(&handler, databaseBuffer);
 }
 
 //! destructor
@@ -171,10 +168,10 @@ IMesh* CSceneManagerWolvenKit::getStaticMesh(const io::path& filename)
 IMeshSceneNode* CSceneManagerWolvenKit::addMeshSceneNode(IMesh* mesh, ISceneNode* parent, s32 id,
 	const core::vector3df& position, const core::vector3df& rotation, const core::vector3df&, bool)
 {
-	IMeshSceneNode* node = DBG_NEW CMeshSceneNode(mesh, parent, this, id, position, rotation);
-	node->setAutomaticCulling(E_CULLING_TYPE::EAC_FRUSTUM_BOX);
-	node->setMaterialFlag(irr::video::E_MATERIAL_FLAG::EMF_BACK_FACE_CULLING, true);
-	node->setMaterialFlag(irr::video::E_MATERIAL_FLAG::EMF_LIGHTING, false);
+    IMeshSceneNode* node = DBG_NEW CMeshSceneNode(mesh, parent, this, id, position, rotation);
+    node->setAutomaticCulling(E_CULLING_TYPE::EAC_FRUSTUM_BOX);
+    node->setMaterialFlag(irr::video::E_MATERIAL_FLAG::EMF_BACK_FACE_CULLING, false);
+    node->setMaterialFlag(irr::video::E_MATERIAL_FLAG::EMF_LIGHTING, false);
     node->setVisible(false);
 
 	node->drop();
@@ -303,7 +300,6 @@ ITerrainSceneNodeWolvenKit* CSceneManagerWolvenKit::addTerrainSceneNodeWolvenKit
     }
 
     core::vector3df pt = anchor;
-    pt.X *= -1.0f; // flip this
     CTerrainSceneNodeWolvenKit* node = DBG_NEW CTerrainSceneNodeWolvenKit(parent, this, id, pt);
 
     if (!node->loadHeightMap(file, dimension, maxHeight, minHeight, tileSize))
@@ -324,49 +320,6 @@ ITerrainSceneNodeWolvenKit* CSceneManagerWolvenKit::addTerrainSceneNodeWolvenKit
 
     node->drop();
 
-#if defined(MAKE_SCENE)
-    // add to pvs scene 
-	u32 numVerts = node->getMesh()->getMeshBuffer(0)->getVertexCount();
-	video::S3DVertex* vertices = static_cast<video::S3DVertex*>(node->getMesh()->getMeshBuffer(0)->getVertices());
-    
-    f32* verts = new f32[numVerts * 3];
-	s32 triangleCount = (dimension - 1) * (dimension - 1) * 2;
-	s32* indices = new s32[triangleCount * 3];
-
-	f32* pVert = verts;
-	video::S3DVertex* pVertex = vertices;
-
-	// Positions
-	for (u32 i = 0; i < numVerts; ++i, ++pVertex)
-	{
-		*pVert++ = pVertex->Pos.X;
-		*pVert++ = pVertex->Pos.Y;
-		*pVert++ = pVertex->Pos.Z;
-	}
-
-	// Faces
-    s32 row0Index = 0;
-    s32 row1Index = dimension;
-	s32* pFace = indices;
-
-	for (u32 y = 0; y < dimension - 1; ++y)
-	{
-		for (u32 x = 0; x < dimension - 1; ++x)
-		{
-			// one row of triangles, two at a time
-			*pFace++ = row0Index++;
-			*pFace++ = row1Index;
-			*pFace++ = row0Index;
-
-            *pFace++ = row0Index;
-            *pFace++ = row1Index++;
-            *pFace++ = row1Index;
-		}
-	}
-
-    Janua::Model* ocModel = new Janua::Model(verts, numVerts, indices, triangleCount);
-    ocScene.addModelInstance((*ocModel), id, Janua::Matrix4x4(), OCCLUDER);
-#endif
 
 	SolidNodeList.push_back(node);
 
@@ -473,16 +426,6 @@ void CSceneManagerWolvenKit::drawAll()
 
 	// render default objects
 	{
-		//TODO: use PVSHandler to get visible set
-		/*
-		janua_query_result result;
-		janua_query_visibility_from_position( &PVSHandler, camWorldPos.X, camWorldPos.Y, camWorldPos.Z, &result );
-	
-		for (u32 i=0; i<result.model_ids_count; ++i)
-		{
-			SolidNodeList[ result.model_ids[i] ]->render();
-		}
-		*/
 #if USE_CULLING
         const SViewFrustum* frust = ActiveCamera->getViewFrustum();
 

--- a/WolvenKit.Irrlicht/source/CTerrainSceneNodeWolvenKit.cpp
+++ b/WolvenKit.Irrlicht/source/CTerrainSceneNodeWolvenKit.cpp
@@ -156,7 +156,7 @@ namespace scene
                     }
                 }
 
-                video::S3DVertex& vertex = static_cast<video::S3DVertex*>(vb.pointer())[index++];
+                video::S3DVertex & vertex = static_cast<video::S3DVertex*>(vb.pointer())[index++];
                 vertex.Normal.set(0.0f, 0.0f, 1.0f);
                 vertex.Color.set(255, r, g, b);
                 vertex.Pos.X = currX;
@@ -168,7 +168,7 @@ namespace scene
                 else if (h > maxZ)
                     maxZ = h;
 
-				currX -= stepSize;
+				currX += stepSize;
 			}
 
 			currY += stepSize;
@@ -229,7 +229,7 @@ namespace scene
 		// add the MeshBuffer to the mesh
 		Mesh->addMeshBuffer(mb);
 
-        irr::core::aabbox3df bounds(-tileSize, 0.0f, minZ, 0.0f, tileSize, maxZ);
+        irr::core::aabbox3df bounds(0.0f, 0.0f, minZ, tileSize, tileSize, maxZ);
         Mesh->setBoundingBox(bounds);
 
 		// We no longer need the mb

--- a/WolvenKit.Irrlicht/source/CW3EntLoader.cpp
+++ b/WolvenKit.Irrlicht/source/CW3EntLoader.cpp
@@ -195,6 +195,7 @@ IMesh* CW3EntLoader::createStaticMesh(io::IReadFile* f)
     {
         _staticMesh->drop();
         _staticMesh = nullptr;
+        return nullptr;
     }
 
     os::Printer::log("LOADING FINISHED", ELL_DEBUG);

--- a/WolvenKit.Render/frmLevelScene.cs
+++ b/WolvenKit.Render/frmLevelScene.cs
@@ -51,43 +51,44 @@ namespace WolvenKit.Render
             float r32 = rm.cy.val;
             float r33 = rm.cz.val;
 
-            float y = -(float)Math.Asin(Clamp(r13, -1.0f, 1.0f));
-            float c = (float)Math.Cos(y);
-            ry = y;
-            if (Math.Abs(ry) >= Math.PI * 2.0)
+            double Y = -Math.Asin(Clamp(r13, -1.0f, 1.0f));
+            double C = Math.Cos(Y);
+            ry = (float)Y;
+
+            double rotx, roty, X, Z;
+
+            if (Math.Abs(C) > 0.0005)
             {
-                ry = 0;
-            }
-
-            y *= (float)(180.0 / Math.PI);
-
-            if (Math.Abs(c) > 0.0005f)
-            {
-                float invC = 1.0f / c;
-                float rotx = r33 * invC;
-                float roty = r23 * invC;
-                rx = (float)Math.Atan2(roty, rotx);
-                if (rx < 0)
-                {
-                    rx += (float)(Math.PI * 2.0);
-                }
-
+                double invC = 1.0 / C;
+                rotx = r33 * invC;
+                roty = r23 * invC;
+                X = Math.Atan2(roty, rotx);
                 rotx = r11 * invC;
                 roty = r12 * invC;
-                rz = (float)Math.Atan2(roty, rotx);
-                if (rz < 0)
-                {
-                    rz += (float)(Math.PI * 2.0);
-                }
+                Z = Math.Atan2(roty, rotx);
             }
             else
             {
-                rx = 0;
-                rz = (float)Math.Atan2(-r21, r22);
-                if (rz < 0)
-                {
-                    rz += (float)(Math.PI * 2.0);
-                }
+                X = 0.0;
+                Z = Math.Atan2(-r21, r22);
+            }
+
+            rx = (float)X;
+            rz = (float)Z;
+
+            if (rx < 0)
+            {
+                rx += (float)(Math.PI * 2.0);
+            }
+
+            if (ry < 0)
+            {
+                ry += (float)(Math.PI * 2.0);
+            }
+
+            if (rz < 0)
+            {
+                rz += (float)(Math.PI * 2.0);
             }
         }
 
@@ -228,9 +229,8 @@ namespace WolvenKit.Render
                             float rx, ry, rz;
                             MatrixToEuler(rot, out rx, out ry, out rz); // radians
 
-                            //NOTE: Flipping the z axis rotation and the x axis translation since the assets seemed to be mirrored.  RHCS vs LHCS?
-                            Vector3Df rotation = new Vector3Df(rx * RADIANS_TO_DEGREES, ry * RADIANS_TO_DEGREES, -rz * RADIANS_TO_DEGREES);
-                            Vector3Df translation = new Vector3Df(-position.X.val, position.Y.val, position.Z.val);
+                            Vector3Df rotation = new Vector3Df(rx * RADIANS_TO_DEGREES, ry * RADIANS_TO_DEGREES, rz * RADIANS_TO_DEGREES);
+                            Vector3Df translation = new Vector3Df(position.X.val, position.Y.val, position.Z.val);
 
                             SBlockDataMeshObject mo = (SBlockDataMeshObject)block.packedObject;
                             ushort meshIndex = mo.meshIndex.val;
@@ -696,7 +696,10 @@ namespace WolvenKit.Render
                 lightNode = smgr.AddLightSceneNode(null, new Vector3Df(0, 0, 0), new Colorf(1.0f, 1.0f, 1.0f), 200000.0f);
                 smgr.AmbientLight = new Colorf(1.0f, 1.0f, 1.0f);
                 worldNode = smgr.AddEmptySceneNode();
+                //NOTE: Witcher assets use Z up but Irrlicht uses Y up so rotate the model
                 worldNode.Rotation = new Vector3Df(-90, 0, 0);
+                //NOTE: We also need to flip the x-coordinate with this rotation
+                worldNode.Scale = new Vector3Df(-1.0f, 1.0f, 1.0f);
                 worldNode.Visible = true;
 
                 var dome = smgr.AddSkyDomeSceneNode(driver.GetTexture("Terrain\\skydome.jpg"), 16, 8, 0.95f, 2.0f);


### PR DESCRIPTION
Fixed coordinate system transformation issue.  Witcher is RHCS and Irrlicht is LHCS.  Hack that was in before had some issues so investigated a better fix - this is it.

Implemented:
- none

Fixed:
- mesh and terrain are loaded as is.  Transformation is applied to a root node in the scene graph.