### PR TITLE
custom enums and chunk copy

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/CR2WDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/CR2WDocumentViewModel.cs
@@ -91,14 +91,9 @@ namespace WolvenKit.App.ViewModels
         #region Commands
         public ICommand CopyVariableCommand { get; }
         public ICommand PasteVariableCommand { get; }
-        //public ICommand OpenChunkFormCommand { get; }
         #endregion
 
         #region Commands Implementation
-
-        //private string openChunkFormRef = "";
-        //public void OpenChunkForm(IEnumerable<string> value) => m_windowFactory.ShowAddChunkFormModal(value, ref openChunkFormRef);
-
         protected bool CanCopyVariable() => true;
 
         protected bool CanPasteVariable() => CopyController.Source != null && CopyController.Target != null;
@@ -127,7 +122,7 @@ namespace WolvenKit.App.ViewModels
             // -------------------------------------------------------------------------------------------------------------------
             // Paste-in-place - 1-->1 - if only one variable was copied and that one variable is of the same type as the target variable
             // -------------------------------------------------------------------------------------------------------------------
-            if (CopyController.Source.Count == 1 && ctarget.GetType() == csource.GetType())
+            if (CopyController.Source.Count == 1 && ctarget.GetType().IsSubclassOf(csource.GetType()))
             {
                 //Remember the old parenting hierarchy
                 var oldparentinghierarchy = new Dictionary<CR2WExportWrapper, (CR2WExportWrapper oldchunkparent, CR2WExportWrapper oldchunkvparent)>();
@@ -200,6 +195,14 @@ namespace WolvenKit.App.ViewModels
                             ctargetptr.ParentVar.AddVariable(uppercopy);
                         }
                     }
+                }
+                else
+                {
+                    context = new CR2WCopyAction()
+                    {
+                        SourceFile = csource.cr2w,
+                        DestinationFile = ctarget.cr2w
+                    };
                 }
 
                 var copy = csource.Copy(context);

--- a/WolvenKit.App/ViewModels/Documents/ScriptDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/ScriptDocumentViewModel.cs
@@ -30,13 +30,46 @@ namespace WolvenKit.App.ViewModels
         #region Properties
         public object SaveTarget { get; set; }
         public string Title => FileName;
-        public bool IsUnsaved { get; set; }
+        public bool IsUnsaved { get; private set; }
 
         public string FilePath { get; set; }
         public string FileName => Path.GetFileName(FilePath);
 
-        public string Text { get; set; }
-        public string FormTitle { get; set; }
+        #region Text
+        private string _text;
+        public string Text
+        {
+            get => _text;
+            set
+            {
+                if (_text != value)
+                {
+                    _text = value;
+                    OnPropertyChanged();
+
+                    // notify unsaved
+                    IsUnsaved = true;
+                    FormTitle = $"{FileName}*";
+                }
+            }
+        }
+        #endregion
+
+        #region FormTitle
+        private string _formTitle;
+        public string FormTitle
+        {
+            get => _formTitle;
+            set
+            {
+                if (_formTitle != value)
+                {
+                    _formTitle = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        #endregion
         #endregion
 
 
@@ -50,20 +83,14 @@ namespace WolvenKit.App.ViewModels
         #endregion
 
         #region Methods
-        
-
         public void SaveFile()
         {
             MainController.Get().ProjectStatus = EProjectStatus.Busy;
             // encode in UTF-16LE
-            Encoding enc = Encoding.Unicode;
+            var enc = Encoding.Unicode;
 
             File.WriteAllText(FilePath, Text, enc);
 
-            //using (var streamWriter = File.AppendText(FilePath))
-            //{
-            //    streamWriter.Write(scintillaControl.Text);
-            //}
             MainController.LogString(FilePath + " saved!", Logtype.Normal);
 
             // register all new classes
@@ -77,15 +104,6 @@ namespace WolvenKit.App.ViewModels
             MainController.LogString(FileName + " saved!\n", Logtype.Success);
             MainController.Get().ProjectStatus = EProjectStatus.Ready;
         }
-
-
-
-
-
-
-
-
-
         #endregion
 
 

--- a/WolvenKit.CR2W/CR2WManager.cs
+++ b/WolvenKit.CR2W/CR2WManager.cs
@@ -145,7 +145,7 @@ namespace WolvenKit.CR2W
             return type;
         }
 
-        public static bool EnumExists(string typeName) => m_enums.ContainsKey(typeName);
+        public static bool EnumExists(string typeName) => m_enums?.ContainsKey(typeName) ?? false;
         #endregion
 
 

--- a/WolvenKit.CR2W/CR2WManager.cs
+++ b/WolvenKit.CR2W/CR2WManager.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using WolvenKit.Common.Services;
 using WolvenKit.Common.Tools;
 using WolvenKit.CR2W.Reflection;
+using WolvenKit.CR2W.Types;
 
 namespace WolvenKit.CR2W
 {
@@ -26,6 +27,7 @@ namespace WolvenKit.CR2W
         private static LoggerService m_logger;
         private static DirectoryInfo m_projectinfo;
         private static Dictionary<string, Type> m_types;
+        private static Dictionary<string, Type> m_enums;
 
         /// <summary>
         /// Gets all available types, custom and vanilla for a given typename
@@ -109,11 +111,50 @@ namespace WolvenKit.CR2W
                 {
                     m_logger.LogString($"Successfully compiled custom assembly {m_assembly.GetName()}", Logtype.Success);
                     LoadTypes();
+                    LoadEnums();
                 }
                 else
                     m_logger.LogString($"Custom class assembly could not be compiled. An error occured", Logtype.Error);
             }
         }
+
+        #region Enums
+        private static void LoadEnums()
+        {
+            m_enums = new Dictionary<string, Type>();
+
+            if (!m_types.ContainsKey("Enums"))
+                return;
+
+
+            foreach (Type type in CR2WManager.GetTypeByName("Enums").GetNestedTypes())
+            {
+                if (!type.IsEnum)
+                    continue;
+
+                if (m_enums.ContainsKey(type.Name))
+                    continue;
+
+                m_enums.Add(type.Name, type);
+            }
+        }
+
+        public static Type GetEnumByName(string typeName)
+        {
+            m_enums.TryGetValue(typeName, out Type type);
+            return type;
+        }
+
+        public static bool EnumExists(string typeName) => m_enums.ContainsKey(typeName);
+        #endregion
+
+
+
+
+
+
+
+
 
 
         private const string header = @"
@@ -145,7 +186,8 @@ namespace WolvenKit.CR2W.Types
 
         private static (int, string) InterpretScriptClasses()
         {
-            List<string> importedClases = new List<string>();
+            List<string> importedClasses = new List<string>();
+            List<string> importedEnums = new List<string>();
             string output = "";
 
             using (StringWriter sw = new StringWriter())
@@ -154,7 +196,85 @@ namespace WolvenKit.CR2W.Types
                 sw.WriteLine(header);
 
                 FileInfo[] projectScriptFiles = m_projectinfo.GetFiles("*.ws", SearchOption.AllDirectories);
-                // all classes
+
+
+                sw.WriteLine("\tpublic static partial class Enums");
+                sw.WriteLine("\t{\r\n");
+                // interpret enums
+                #region Enums
+                foreach (var file in projectScriptFiles)
+                {
+                    int depth = 0;
+                    bool isReading = false;
+                    string enumname = "";
+                    string enumstring = "";
+
+                    var lines = File.ReadLines(file.FullName);
+                    foreach (var line in lines)
+                    {
+                        // check if should start reading
+                        if (line.Contains("enum "))
+                        {
+
+                            // interpret line
+                            string intline = InterpretEnumLine(line, ref enumname);
+                            if (!string.IsNullOrEmpty(intline))
+                            {
+                                // check if enum is vanilla
+                                if (AssemblyDictionary.EnumExists(enumname))
+                                    continue;
+                                if (importedEnums.Contains(enumname))
+                                    continue;
+
+                                enumstring += $"\t{intline}\r\n";
+
+                                isReading = true;
+                            }
+
+                            // increment or decrement the depth
+                            depth += line.Count(_ => _ == '{');
+                            depth -= line.Count(_ => _ == '}');
+                            continue;
+                        }
+
+                        // if reading, interpret results
+                        if (isReading)
+                        {
+                            // increment or decrement the depth
+                            depth += line.Count(_ => _ == '{');
+                            depth -= line.Count(_ => _ == '}');
+
+                            // only interpret variables at depth 1 (from the class depth)
+                            if (depth == 1)
+                            {
+                                if (!string.IsNullOrEmpty(line))
+                                {
+                                    var iline = InterpretEnumVarLine(line);
+                                    if (!string.IsNullOrEmpty(iline))
+                                    {
+                                        enumstring += $"\t\t\t{iline}\r\n";
+                                    }
+                                }
+                            }
+
+                            // if depth is 0 again, stop reading and write to output
+                            if (depth == 0)
+                            {
+                                sw.WriteLine(enumstring);
+                                sw.WriteLine("\t\t}");
+
+                                isReading = false;
+                                enumstring = "";
+                                importedEnums.Add(enumname);
+                            }
+                        }
+                    }
+                }
+                #endregion
+                sw.WriteLine("\t}\r\n");
+
+                // interpret classes
+                #region Classes
                 foreach (var file in projectScriptFiles)
                 {
                     int depth = 0;
@@ -177,7 +297,7 @@ namespace WolvenKit.CR2W.Types
                                 // check if class is vanilla
                                 if (AssemblyDictionary.TypeExists(classname))
                                     continue;
-                                if (importedClases.Contains(classname))
+                                if (importedClasses.Contains(classname))
                                     continue;
 
                                 classstring += $"{intline}\r\n";
@@ -190,10 +310,6 @@ namespace WolvenKit.CR2W.Types
                             depth -= line.Count(_ => _ == '}');
                             continue;
                         }
-                        else if (line.Contains("enum "))
-                        {
-
-                        }
 
                         // if reading, interpret results
                         if (isReading)
@@ -205,7 +321,7 @@ namespace WolvenKit.CR2W.Types
                             // only interpret variables at depth 1 (from the class depth)
                             if (depth == 1)
                             {
-                                string intline = InterpretVarLine(line, varcounter);
+                                string intline = InterpretVarLine(line, varcounter, importedEnums);
                                 if (!string.IsNullOrEmpty(intline))
                                 {
                                     classstring += $"{intline}";
@@ -223,25 +339,27 @@ namespace WolvenKit.CR2W.Types
                                 varcounter = 0;
                                 isReading = false;
                                 classstring = "";
-                                importedClases.Add(classname);
+                                importedClasses.Add(classname);
                             }
                         }
                     }
                 }
+                #endregion
+
 
                 // namespace end
                 sw.WriteLine("}");
                 output = sw.ToString();
             }
 
-            if (importedClases.Count > 0)
-                if (m_logger != null) m_logger.LogString($"Sucessfully parsed {importedClases.Count} custom classes: " +
-                $"{string.Join(", ", importedClases)}", Logtype.Success);
-            return (importedClases.Count, output);
+            if (importedClasses.Count > 0)
+                if (m_logger != null) m_logger.LogString($"Sucessfully parsed {importedClasses.Count} custom classes: " +
+                $"{string.Join(", ", importedClasses)}", Logtype.Success);
+            return (importedClasses.Count, output);
         }
 
 
-        private static string InterpretVarLine(string input, int counter)
+        private static string InterpretVarLine(string input, int counter, List<string> customenums)
         {
             string csline = "";
 
@@ -251,8 +369,7 @@ namespace WolvenKit.CR2W.Types
             {
                 string redtype = matchIsVar.Groups["VARTYPE"].Value;
                 // support generic types (e.g. array<string>)
-                string vartype = GetCsTypeRecursive(redtype);
-
+                string vartype = GetCsTypeRecursive(redtype, customenums);
 
                 string varname = matchIsVar.Groups["VARNAME"].Value;
                 // support multiple var declarations in one line (e.g. var i, j, size : int;)
@@ -278,7 +395,20 @@ namespace WolvenKit.CR2W.Types
             return csline;
         }
 
-        private static string GetCsTypeRecursive(string input)
+        private static string InterpretEnumVarLine(string input)
+        {
+            string csline = "";
+            var regvar = new Regex(@"\.*(?<VARNAME>\w+)\.*");
+            var matchIsVar = regvar.Match(input);
+            if (matchIsVar.Success)
+            {
+                csline = $"{matchIsVar.Groups["VARNAME"].Value},";
+            }
+
+            return csline;
+        }
+
+        private static string GetCsTypeRecursive(string input, List<string> customenums)
         {
             if (input.Contains("array")) // TODO: support for more generics?
             {
@@ -291,7 +421,7 @@ namespace WolvenKit.CR2W.Types
                 if (matchIsArray.Success)
                 {
                     var typename = matchIsArray.Groups["TYPE"].Value;
-                    returntype = $"CArray<{GetCsTypeRecursive(typename)}>";
+                    returntype = $"CArray<{GetCsTypeRecursive(typename, customenums)}>";
                 }
                 else
                 {
@@ -302,7 +432,7 @@ namespace WolvenKit.CR2W.Types
             else
             {
                 input = input.Trim(' ');
-                if (AssemblyDictionary.EnumExists(input))
+                if (AssemblyDictionary.EnumExists(input) || customenums.Contains(input))
                     input = $"CEnum<{input}>";
                 return REDReflection.GetWKitBaseTypeFromREDBaseType(input);
             }
@@ -343,6 +473,22 @@ namespace WolvenKit.CR2W.Types
 
             }
 
+
+            return csline;
+        }
+
+        private static string InterpretEnumLine(string input, ref string enumname)
+        {
+            string csline = "";
+
+            // check if class
+            var regClass = new Regex(@"(.*)enum\s+(\w+)(.*)");
+            var matchIsClass = regClass.Match(input);
+            if (matchIsClass.Success)
+            {
+                enumname = matchIsClass.Groups[2].Value;
+                csline += $"\tpublic enum {enumname}\r\n\t\t{{";
+            }
 
             return csline;
         }

--- a/WolvenKit.CR2W/CR2WTypeManager.cs
+++ b/WolvenKit.CR2W/CR2WTypeManager.cs
@@ -65,6 +65,12 @@ namespace WolvenKit.CR2W.Types
                 var cenum = MakeGenericEnumType(typeof(CEnum<>), e);
                 return cenum;
             }
+            else if (CR2WManager.EnumExists(typename))
+            {
+                Enum e = (Enum)Activator.CreateInstance(CR2WManager.GetEnumByName(typename));
+                var cenum = MakeGenericEnumType(typeof(CEnum<>), e);
+                return cenum;
+            }
             // check for generic type
             else if (typename.Contains(':'))
             {
@@ -305,13 +311,22 @@ namespace WolvenKit.CR2W.Types
 
         private static Enum CreateEnum(string value)
         {
-            var type = AssemblyDictionary.GetEnumByName(value);
-            Enum e = (Enum)Activator.CreateInstance(type);
+            if (AssemblyDictionary.EnumExists(value))
+            {
+                var type = AssemblyDictionary.GetEnumByName(value);
+                Enum e = (Enum) Activator.CreateInstance(type);
 
-            return e;
+                return e;
+            }
+            else if (CR2WManager.EnumExists(value))
+            {
+                var type = CR2WManager.GetEnumByName(value);
+                Enum e = (Enum)Activator.CreateInstance(type);
+
+                return e;
+            }
+
+            return null;
         }
-
-
-        
     }
 }

--- a/WolvenKit.CR2W/Types/Primitive/Enums.cs
+++ b/WolvenKit.CR2W/Types/Primitive/Enums.cs
@@ -7,8 +7,9 @@ using System.Threading.Tasks;
 
 namespace WolvenKit.CR2W.Types
 {
-    public static class Enums
+    public static partial class Enums
     {
+
         public enum ETextureCompression
         {
             TCM_None,

--- a/WolvenKit/Forms/MVVM/frmMain.Designer.cs
+++ b/WolvenKit/Forms/MVVM/frmMain.Designer.cs
@@ -159,6 +159,7 @@ namespace WolvenKit
             this.MainBackgroundWorker = new System.ComponentModel.BackgroundWorker();
             this.visualStudioToolStripExtender2 = new WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender(this.components);
             this.watcher = new System.IO.FileSystemWatcher();
+            this.resetDocumentLayoutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolbarToolStrip.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.statusToolStrip.SuspendLayout();
@@ -923,8 +924,9 @@ namespace WolvenKit
             this.consoleToolStripMenuItem,
             this.scriptToolStripMenuItem,
             this.importUtilityToolStripMenuItem,
+            this.radishUtilitytoolStripMenuItem,
             this.toolStripSeparator9,
-            this.radishUtilitytoolStripMenuItem});
+            this.resetDocumentLayoutToolStripMenuItem});
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
             this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 24);
             this.viewToolStripMenuItem.Text = "View";
@@ -934,7 +936,7 @@ namespace WolvenKit
             // 
             this.modExplorerToolStripMenuItem.Image = global::WolvenKit.Properties.Resources.RemoteServer_16x;
             this.modExplorerToolStripMenuItem.Name = "modExplorerToolStripMenuItem";
-            this.modExplorerToolStripMenuItem.Size = new System.Drawing.Size(184, 26);
+            this.modExplorerToolStripMenuItem.Size = new System.Drawing.Size(204, 26);
             this.modExplorerToolStripMenuItem.Text = "Mod Explorer";
             this.modExplorerToolStripMenuItem.Click += new System.EventHandler(this.modExplorerToolStripMenuItem_Click);
             // 
@@ -942,7 +944,7 @@ namespace WolvenKit
             // 
             this.outputToolStripMenuItem.Image = global::WolvenKit.Properties.Resources.Output_16x;
             this.outputToolStripMenuItem.Name = "outputToolStripMenuItem";
-            this.outputToolStripMenuItem.Size = new System.Drawing.Size(184, 26);
+            this.outputToolStripMenuItem.Size = new System.Drawing.Size(204, 26);
             this.outputToolStripMenuItem.Text = "Output";
             this.outputToolStripMenuItem.Click += new System.EventHandler(this.OutputToolStripMenuItem_Click);
             // 
@@ -950,7 +952,7 @@ namespace WolvenKit
             // 
             this.consoleToolStripMenuItem.Image = global::WolvenKit.Properties.Resources.Console_16x;
             this.consoleToolStripMenuItem.Name = "consoleToolStripMenuItem";
-            this.consoleToolStripMenuItem.Size = new System.Drawing.Size(184, 26);
+            this.consoleToolStripMenuItem.Size = new System.Drawing.Size(204, 26);
             this.consoleToolStripMenuItem.Text = "Console";
             this.consoleToolStripMenuItem.Click += new System.EventHandler(this.consoleToolStripMenuItem_Click);
             // 
@@ -959,7 +961,7 @@ namespace WolvenKit
             this.scriptToolStripMenuItem.Enabled = false;
             this.scriptToolStripMenuItem.Image = global::WolvenKit.Properties.Resources.PlayStep_16x;
             this.scriptToolStripMenuItem.Name = "scriptToolStripMenuItem";
-            this.scriptToolStripMenuItem.Size = new System.Drawing.Size(184, 26);
+            this.scriptToolStripMenuItem.Size = new System.Drawing.Size(204, 26);
             this.scriptToolStripMenuItem.Text = "Script Manager";
             this.scriptToolStripMenuItem.Click += new System.EventHandler(this.scriptToolStripMenuItem_Click);
             // 
@@ -967,7 +969,7 @@ namespace WolvenKit
             // 
             this.importUtilityToolStripMenuItem.Image = global::WolvenKit.Properties.Resources.ImportPackage_16x;
             this.importUtilityToolStripMenuItem.Name = "importUtilityToolStripMenuItem";
-            this.importUtilityToolStripMenuItem.Size = new System.Drawing.Size(184, 26);
+            this.importUtilityToolStripMenuItem.Size = new System.Drawing.Size(204, 26);
             this.importUtilityToolStripMenuItem.Text = "Import Utility";
             this.importUtilityToolStripMenuItem.ToolTipText = "Utility for importing raw assets to CR2W files (e.g. FBX to w2mesh)";
             this.importUtilityToolStripMenuItem.Click += new System.EventHandler(this.importUtilityToolStripMenuItem_Click);
@@ -975,13 +977,13 @@ namespace WolvenKit
             // toolStripSeparator9
             // 
             this.toolStripSeparator9.Name = "toolStripSeparator9";
-            this.toolStripSeparator9.Size = new System.Drawing.Size(181, 6);
+            this.toolStripSeparator9.Size = new System.Drawing.Size(201, 6);
             // 
             // radishUtilitytoolStripMenuItem
             // 
             this.radishUtilitytoolStripMenuItem.Image = global::WolvenKit.Properties.Resources.radish_32x;
             this.radishUtilitytoolStripMenuItem.Name = "radishUtilitytoolStripMenuItem";
-            this.radishUtilitytoolStripMenuItem.Size = new System.Drawing.Size(184, 26);
+            this.radishUtilitytoolStripMenuItem.Size = new System.Drawing.Size(204, 26);
             this.radishUtilitytoolStripMenuItem.Text = "Radish Utility";
             this.radishUtilitytoolStripMenuItem.ToolTipText = "Utility for managing Radish project directory (installed separately)";
             this.radishUtilitytoolStripMenuItem.Click += new System.EventHandler(this.RadishUtilitytoolStripMenuItem_Click);
@@ -1267,6 +1269,13 @@ namespace WolvenKit
             this.watcher.Deleted += new System.IO.FileSystemEventHandler(this.FileChanges_Detected);
             this.watcher.Renamed += new System.IO.RenamedEventHandler(this.FileRenames_Detected);
             // 
+            // resetDocumentLayoutToolStripMenuItem
+            // 
+            this.resetDocumentLayoutToolStripMenuItem.Name = "resetDocumentLayoutToolStripMenuItem";
+            this.resetDocumentLayoutToolStripMenuItem.Size = new System.Drawing.Size(204, 26);
+            this.resetDocumentLayoutToolStripMenuItem.Text = "Reset Document Layout";
+            this.resetDocumentLayoutToolStripMenuItem.Click += new System.EventHandler(this.resetDocumentLayoutToolStripMenuItem_Click);
+            // 
             // frmMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1427,5 +1436,6 @@ namespace WolvenKit
         private ToolStripMenuItem commandPromptHereToolStripMenuItem1;
         private ToolStripSeparator toolStripSeparator14;
         private ToolStripButton toolStripButtonLexarMode;
+        private ToolStripMenuItem resetDocumentLayoutToolStripMenuItem;
     }
 }

--- a/WolvenKit/Forms/MVVM/frmMain.cs
+++ b/WolvenKit/Forms/MVVM/frmMain.cs
@@ -1,5 +1,6 @@
 ﻿using AutoUpdaterDotNET;
 using Dfust.Hotkeys;
+using Microsoft.VisualBasic.FileIO;
 using SharpPresence;
 using System;
 using System.Collections.Generic;
@@ -7,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -17,36 +19,34 @@ using System.Windows.Forms;
 using System.Xml.Linq;
 using System.Xml.Serialization;
 using WeifenLuo.WinFormsUI.Docking;
-using SearchOption = System.IO.SearchOption;
-using System.IO.MemoryMappedFiles;
-using Microsoft.VisualBasic.FileIO;
 using WolvenKit.App.Model;
+using SearchOption = System.IO.SearchOption;
 
 namespace WolvenKit
 {
+    using App;
+    using App.Commands;
+    using App.ViewModels;
+    using Bundles;
     using Cache;
     using Common;
+    using Common.Extensions;
+    using Common.Model;
     using Common.Services;
     using Common.Wcc;
     using CR2W;
     using CR2W.Types;
     using Extensions;
     using Forms;
-    using App;
-    using App.Commands;
-    using App.ViewModels;
-    using Bundles;
-    using Common.Extensions;
-    using Common.Model;
     using Forms.MVVM;
+    using Microsoft.WindowsAPICodePack.Dialogs;
     using Render;
     using Scaleform;
+    using System.Globalization;
+    using WolvenKit.CR2W.Reflection;
     using Wwise.Player;
     using Wwise.Wwise;
     using Enums = Enums;
-    using WolvenKit.CR2W.Reflection;
-    using Microsoft.WindowsAPICodePack.Dialogs;
-    using System.Globalization;
 
     public partial class frmMain : Form
     {
@@ -3708,12 +3708,12 @@ Would you like to open the problem steps recorder?", "Bug reporting", MessageBox
             if (dlg.ShowDialog() == CommonFileDialogResult.Ok)
             {
                 // parse the w2w and provide information to the scene
-                Render.frmLevelScene sceneView = new Render.frmLevelScene(dlg.FileName, MainController.Get().Configuration.DepotPath, MainController.Get().TextureManager);
+                var sceneView = new Render.frmLevelScene(dlg.FileName, MainController.Get().Configuration.DepotPath, MainController.Get().TextureManager);
                 sceneView.Show(this.dockPanel, DockState.Document);
             }
         }
 
-        void toolStripDropDownButtonGit_Paint(object sender, PaintEventArgs e)
+        private void toolStripDropDownButtonGit_Paint(object sender, PaintEventArgs e)
         {
             if (toolStripDropDownButtonGit.Pressed)
             {
@@ -3825,7 +3825,6 @@ Would you like to open the problem steps recorder?", "Bug reporting", MessageBox
                 MainController.Get().StatusProgress = 100;
                 MainController.Get().ProjectStatus = EProjectStatus.Ready;
                 MainController.LogString($"Error creating git archive for project {ActiveMod.Name}.", Logtype.Error);
-                return;
             }
         }
 
@@ -3833,6 +3832,26 @@ Would you like to open the problem steps recorder?", "Bug reporting", MessageBox
 
         private void commandPromptHereToolStripMenuItem_Click(object sender, EventArgs e) => Commonfunctions.OpenConsoleAtPath(ActiveMod.ProjectDirectory);
 
-        
+        private void resetDocumentLayoutToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (vm.GetOpenDocuments().Any())
+            {
+                MainController.LogString($"Please close all open documents.", Logtype.Error);
+                return;
+            }
+
+            try
+            {
+                var doclayoutconfig = Path.Combine(Path.GetDirectoryName(Configuration.ConfigurationPath),
+                    "cr2wdocument_layout.xml");
+                if (File.Exists(doclayoutconfig))
+                    File.Delete(doclayoutconfig);
+                MainController.LogString($"Reset document layout.", Logtype.Success);
+            }
+            catch (Exception exception)
+            {
+
+            }
+        }
     }
 }

--- a/WolvenKit/Forms/frmChunkProperties.cs
+++ b/WolvenKit/Forms/frmChunkProperties.cs
@@ -330,8 +330,14 @@ namespace WolvenKit.Forms
                     // if only one variable was copied and that one variable is of the same type as the selected variable
                     if (CopyController.Source.Count == 1 
                         && CopyController.Source.First() is CVariable ccopy 
-                        && ctarget.GetType() == ccopy.GetType())
+                        /*&& ctarget.GetType() == ccopy.GetType()*/)
                     {
+                        // check if source type is subtype of targettype
+                        if (ctarget.GetType().IsSubclassOf(ccopy.GetType()))
+                            return true;
+                        if (ccopy.GetType().IsSubclassOf(ctarget.GetType()))
+                            return false;
+
                         return true;
                     }
 

--- a/WolvenKit/Forms/frmScriptEditor.cs
+++ b/WolvenKit/Forms/frmScriptEditor.cs
@@ -18,18 +18,19 @@ namespace WolvenKit.Forms
     public partial class frmScriptEditor : DockContent, IWolvenkitView
     {
         private const bool CodeFoldingCircular = true;
-        private readonly FindReplace ScintillaFindReplace;
+        private readonly FindReplace scintillaFindReplace;
         private readonly ScriptDocumentViewModel vm;
+        private delegate void StrDelegate(string t);
 
-        public string autocompletelist = "array< PushBack string int integer bool float name range event function abstract " +
-                                         "const final private protected public theGame theInput thePlayer " +
-                                         "theSound enum struct state array false NULL true out inlined autobind editable " +
-                                         "entry exec hint import latent optional out quest saved statemachine timer break case" +
-                                         " continue else for if return switch while";
-        
+        private const string Autocompletelist =
+            "array< PushBack string int integer bool float name range event function abstract " +
+            "const final private protected public theGame theInput thePlayer " +
+            "theSound enum struct state array false NULL true out inlined autobind editable " +
+            "entry exec hint import latent optional out quest saved statemachine timer break case" +
+            " continue else for if return switch while";
+
 
         public string FileName => vm.FileName;
-
         public IDocumentViewModel GetViewModel() => vm;
 
         public frmScriptEditor(ScriptDocumentViewModel documentViewModel)
@@ -42,8 +43,8 @@ namespace WolvenKit.Forms
             InitializeComponent();
             ApplyCustomTheme();
 
-            ScintillaFindReplace = new FindReplace(scintillaControl);
-            ScintillaFindReplace.KeyPressed += ScintillaFindReplaceOnKeyPressed;
+            scintillaFindReplace = new FindReplace(scintillaControl);
+            scintillaFindReplace.KeyPressed += ScintillaFindReplaceOnKeyPressed;
             this.ShowIcon = false;
 
             ConfigureScintilla();
@@ -57,8 +58,13 @@ namespace WolvenKit.Forms
             switch (e.PropertyName)
             {
                 case nameof(vm.FormTitle):
+                {
+                    Invoke(new StrDelegate(SetFormTitle), vm.FormTitle);
                     break;
+                }
             }
+
+            void SetFormTitle(string text) => this.Text = text;
         }
 
         public void LoadFile(string path)
@@ -94,14 +100,8 @@ namespace WolvenKit.Forms
             if (lenEntered > 0)
             {
                 if (!scintillaControl.AutoCActive)
-                    scintillaControl.AutoCShow(lenEntered, autocompletelist);
+                    scintillaControl.AutoCShow(lenEntered, Autocompletelist);
             }
-
-            // notify unsaved
-            vm.IsUnsaved = true;
-            this.Text = $"{vm.FileName}*";
-
-            
         }
 
         private void SetupSyntaxHighlighting()
@@ -227,27 +227,27 @@ namespace WolvenKit.Forms
             }
             else if (e.Shift && e.KeyCode == Keys.F3)
             {
-                ScintillaFindReplace.Window.FindPrevious();
+                scintillaFindReplace.Window.FindPrevious();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.F3)
             {
-                ScintillaFindReplace.Window.FindNext();
+                scintillaFindReplace.Window.FindNext();
                 e.SuppressKeyPress = true;
             }
             else if (e.Control && e.KeyCode == Keys.F)
             {
-                ScintillaFindReplace.ShowFind();
+                scintillaFindReplace.ShowFind();
                 e.SuppressKeyPress = true;
             }
             else if (e.Control && e.KeyCode == Keys.H)
             {
-                ScintillaFindReplace.ShowReplace();
+                scintillaFindReplace.ShowReplace();
                 e.SuppressKeyPress = true;
             }
             else if (e.Control && e.KeyCode == Keys.I)
             {
-                ScintillaFindReplace.ShowIncrementalSearch();
+                scintillaFindReplace.ShowIncrementalSearch();
                 e.SuppressKeyPress = true;
             }
             else if (e.Control && e.KeyCode == Keys.G)


### PR DESCRIPTION
# custom enums and chunk copy

Implemented:
- add copy-paste for derived types
- add compilation of custom enums
- added a document layout resest option in case sthg goes wrong

Fixed:
- fixed a bug where copying localized strings would crash
- fixed a bug where the script editor would not change title when saving

<Additional notes>
