### PR TITLE
Update Nightly.yml

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -21,8 +21,8 @@ jobs:
       uses: warrenbuckley/Setup-Nuget@v1
     - name: Restore packages
       run: nuget restore WolvenKit.sln
-    - name: Setup MSBuild.exe
-      uses: warrenbuckley/Setup-MSBuild@v1
+    - name: Setup NuGet.exe for use with actions
+      uses: NuGet/setup-nuget@v1.0.5
     - name: Build with MSBuild
       run: msbuild  WolvenKit.sln -p:Configuration=Release  -p:Platform=x64 -m
     - name: Zip Release


### PR DESCRIPTION
# Fix Github Actions Setup Nuget

Fixed:
- fixed workfow file after deprecation of add-path command (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/): migrated to https://github.com/marketplace/actions/setup-nuget-exe-for-use-with-actions


<Additional notes>
