### PR TITLE
Fix Github Actions - Setup Nuget and ms build

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -17,12 +17,14 @@ jobs:
         lfs: true
     - name: Checkout LFS objects
       run: git lfs checkout
-    - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
-    - name: Restore packages
-      run: nuget restore WolvenKit.sln
     - name: Setup NuGet.exe for use with actions
       uses: NuGet/setup-nuget@v1.0.5
+      with:
+        nuget-version: latest
+    - name: Restore packages
+      run: nuget restore WolvenKit.sln
+    - name: setup-msbuild
+      uses: microsoft/setup-msbuild@v1
     - name: Build with MSBuild
       run: msbuild  WolvenKit.sln -p:Configuration=Release  -p:Platform=x64 -m
     - name: Zip Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,12 @@ jobs:
     - name: Checkout LFS objects
       run: git lfs checkout
     - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
+      uses: NuGet/setup-nuget@v1.0.5
+      with:
+        nuget-version: latest
     - name: Restore packages
       run: nuget restore WolvenKit.sln
     - name: Setup MSBuild.exe
-      uses: warrenbuckley/Setup-MSBuild@v1
+      uses: microsoft/setup-msbuild@v1
     - name: Build with MSBuild
       run: msbuild  WolvenKit.sln -p:Configuration=Release -p:Platform=x64 -m


### PR DESCRIPTION
# 
Fixed:
- fixed workfow file after deprecation of add-path command (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/): migrated to https://github.com/marketplace/actions/setup-nuget-exe-for-use-with-actions

<Additional notes>
