### PR TITLE
frmRender lods

### DIFF
--- a/WolvenKit.Render/frmRender.Designer.cs
+++ b/WolvenKit.Render/frmRender.Designer.cs
@@ -233,7 +233,7 @@
             // 
             // exportToolStripMenuItem
             // 
-            this.exportToolStripMenuItem.Enabled = false;
+            //this.exportToolStripMenuItem.Enabled = false;
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
             this.exportToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
             this.exportToolStripMenuItem.Text = "Export";

--- a/WolvenKit.Render/frmRender.cs
+++ b/WolvenKit.Render/frmRender.cs
@@ -224,8 +224,13 @@ namespace WolvenKit.Render
                 mAnimText.BackgroundColor = mPositionText.BackgroundColor = mRotationText.BackgroundColor = fpsText.BackgroundColor = infoText.BackgroundColor = new Color(0, 0, 0);
 
                 skinnedMesh = smgr.CreateSkinnedMesh();
-                foreach (var meshBuffer in cdata.staticMesh.MeshBuffers)
+                //foreach (var meshBuffer in cdata.staticMesh.MeshBuffers)
+                //    skinnedMesh.AddMeshBuffer(meshBuffer);
+
+                AnimatedMesh am = smgr.GetMesh(meshFile.FileName);
+                foreach (var meshBuffer in am.MeshBuffers)
                     skinnedMesh.AddMeshBuffer(meshBuffer);
+
                 smgr.MeshManipulator.RecalculateNormals(skinnedMesh);
                 if (RigFile != null)
                 {

--- a/WolvenKit.Render/frmRenderEventHandler.cs
+++ b/WolvenKit.Render/frmRenderEventHandler.cs
@@ -8,6 +8,8 @@ using System.Windows.Forms;
 using System.IO;
 using System.Collections.Generic;
 using WolvenKit.Common.Services;
+using WolvenKit.CR2W;
+using WolvenKit.CR2W.Types;
 using MessageBoxButtons = System.Windows.Forms.MessageBoxButtons;
 using MessageBoxIcon = System.Windows.Forms.MessageBoxIcon;
 
@@ -322,7 +324,18 @@ namespace WolvenKit.Render
                 var ofd = new OpenFileDialog();
                 ofd.Filter = "Rig file|*.w2rig";
                 if (ofd.ShowDialog() == DialogResult.OK)
-                    RigFile = LoadDocument(ofd.FileName);
+                {
+                    //RigFile = LoadDocument(ofd.FileName);
+                    using (var fs = new FileStream(ofd.FileName, FileMode.Open, FileAccess.Read))
+                    using (var reader = new BinaryReader(fs))
+                    {
+                        CR2WFile cr2w = new CR2WFile();
+                        cr2w.Read(reader);
+                        fs.Close();
+
+                        RigFile = cr2w;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
frmRender levels of detail for exporting

Fixed:
- loading all lod meshbuffers

Loading all mesh buffers using the scenegraph mesh loading rather than WKMesh since WKMesh only loads the first lod.  We need to clean up frmRender and fastRender as they both do similar things but in different ways which makes maintenance difficult.
